### PR TITLE
Correction du bug #737 lié à l'utilisation du paramètre styletitle

### DIFF
--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -2671,7 +2671,8 @@ mviewer = (function () {
         layer.styles.split(",").forEach(function (style, i) {
           styles.push({ style: style, label: layer.stylesalias.split(",")[i] });
         });
-        view.styles = styles;
+        view.styles = styles;        
+        view.styleTitle = layer.styletitle;
       }
 
       if (
@@ -2681,7 +2682,6 @@ mviewer = (function () {
       ) {
         view.attributeControl = true;
         view.attributeLabel = layer.attributelabel;
-        view.styleTitle = layer.styletitle;
         var options = [];
         if (layer.attributefilterenabled === false) {
           options.push({ label: "Par défaut", attribute: "all" });

--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -2671,7 +2671,7 @@ mviewer = (function () {
         layer.styles.split(",").forEach(function (style, i) {
           styles.push({ style: style, label: layer.stylesalias.split(",")[i] });
         });
-        view.styles = styles;        
+        view.styles = styles;
         view.styleTitle = layer.styletitle;
       }
 


### PR DESCRIPTION
Le paramètre styleTitle n'est pas pris en compte si on ne renseigne pas les paramètres attributeX : 

```
attributefilter 
attributevalues
attributefield 
```

Cette PR corrige ce comportement et permet de prendre en compte le paramètre `styleTitle` sans renseigner ses champs.