### PR TITLE
Correction de la syntaxe font awesome pour le paramètre icon help #740

### DIFF
--- a/docs/doc_tech/config_app.rst
+++ b/docs/doc_tech/config_app.rst
@@ -66,7 +66,7 @@ Paramètres secondaires
 
 * ``titlehtml`` :guilabel:`studio` : optionnel de type texte, il permet d'utiliser du HTML uniquement pour le titre de l'application. Utiliser **title** avec ce paramètre pour le titre de l'onglet et la page de chargement.
 * ``titlehelp`` :guilabel:`studio` : paramètre optionnel de type texte qui définit le titre de la popup d'aide. Valeur par défaut **Documentation**.
-* ``iconhelp`` :guilabel:`studio` : paramètre optionnel de type texte qui précise l'icône à utiliser afin d'illustrer la thématique. Les valeurs possibles sont à choisir parmi cette liste sur le site Fontawesome : https://fontawesome.com/v5/search?m=free
+* ``iconhelp`` :guilabel:`studio` : paramètre optionnel de type texte qui précise l'icône à utiliser afin d'illustrer la thématique. Le nom de l'icône doit être renseigné sous cette forme fab fa-apple ou fas fa-mobile. Les valeurs possibles sont à choisir parmi cette liste (cliquez sur l'icône souhaité pour obtenir la syntaxe) sur le site Fontawesome : https://fontawesome.com/v5/search?m=free
 * ``stats``: paramètre optionnel de type booléen (true/false) activant l'envoi de stats d'utilisation l'application. Valeur par défaut **false**.
 * ``statsurl``: paramètre optionnel de type url précisant l'url du service reccueillant les données d'utilisation de l'application (ip, application title, date). Ce service n'est pas proposé dans mviewer.
 * ``coordinates`` :guilabel:`studio` : paramètre optionnel de type booléen (true/false) activant l'affichage des coordonnées GPS ( navbar) lors de l'interrogation. Valeur par défaut **false**.

--- a/js/configuration.js
+++ b/js/configuration.js
@@ -357,7 +357,7 @@ var configuration = (function () {
       $("#help h4.modal-title").text(conf.application.titlehelp);
     }
     if (conf.application.iconhelp) {
-      $("#iconhelp span").attr("class", "fa fa-" + conf.application.iconhelp);
+      $("#iconhelp span").attr("class", conf.application.iconhelp);
     }
     if (conf.application.coordinates === "true") {
       _captureCoordinates = true;


### PR DESCRIPTION
Auparavant, quand on renseignait un icône font awesome pour le paramètre icon help, il ajoutait automatique "fa fa-" devant l'icône déclaré engendrant certains problèmes : 
- Les icônes avec le préfixe **fab** sont non reconnus : `class="fa fa-fab fa-apple"`
- Les icônes avec le préfixe **fas** sont reconnus mais mal renseignés : `class="fa fa-fas fa-asterisk"`

Ce problème est corrigé en supprimant le préfixe "fa fa-" automatiquement ajouté. 

**Attention, cette modification peut engendrer des régressions et notamment pour les fichiers de configuration où seul le nom de l'icône est déclaré.** 
Exemple : 
`iconhelp="home" `
doit être ajusté en 
`iconhelp="fas fa-home"`

ET ajustement de la documentation pour ce paramètre