### PR TITLE
Fix mviewer#729: use proxy only when specified

### DIFF
--- a/js/info.js
+++ b/js/info.js
@@ -668,9 +668,13 @@ var info = (function () {
     var ajaxFunction = function () {
       urls.forEach(function (request) {
         var _ba_ident = sessionStorage.getItem(request.layerinfos.url);
+        var optionalProxy = '';
+        if (request.layerinfos.useproxy) {
+          optionalProxy = configuration.getConfiguration().proxy.url;
+        }
         requests.push(
           $.ajax({
-            url: mviewer.ajaxURL(request.url),
+            url: mviewer.ajaxURL(request.url, optionalProxy),
             layer: request.layerinfos,
             beforeSend: function (req) {
               if (_ba_ident)

--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -133,8 +133,6 @@ mviewer = (function () {
     } else {
       if (optionalProxy) {
         return optionalProxy + encodeURIComponent(url);
-      } else if (_proxy) {
-        return _proxy + encodeURIComponent(url);
       } else {
         return url;
       }


### PR DESCRIPTION
Correctif simple pour la résolution de l'issue #729 

Idée générale : au moment de l'appel Ajax pour le GetFeatureInfo, vérifier si la couche a le paramètre useproxy à true. Si c'est le cas, passer la valeur du proxy renseignée lors de la requête Ajax.