### PR TITLE
Paramétrage de thèmes externes #616

### DIFF
--- a/demo/external.xml
+++ b/demo/external.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+<application
+    title="Import thématique externe"
+    logo=""
+    favicon=""
+    help=""
+    titlehelp=""
+    iconhelp="fas fa-home"
+    home=""
+    style="css/themes/alizarin.css"
+    zoomtools="true"
+    initialextenttool="true"
+    exportpng="false"
+    showhelp="false"
+    coordinates="false"
+    measuretools="true"
+    mouseposition="false"
+    geoloc="false"
+    studio=""
+    togglealllayersfromtheme="false">
+</application>
+<mapoptions maxzoom="20" projection="EPSG:3857" center="-307903.74898791354,6141345.088741366" zoom="7" />
+<proxy url=""/>
+<olscompletion type="ban" url="https://api-adresse.data.gouv.fr/search/" attribution="Base adresse nationale (BAN)" />
+<searchparameters bbox="false" localities="true" features="false" static="false"/>
+<baselayers style="default">
+    <baselayer visible="true" id="positron" thumbgallery="img/basemap/positron.png" title="CartoDb" label="Positron" type="OSM" url="https://{a-c}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png" attribution="Map tiles by  &lt;a href=&quot;https://cartodb.com/attributions&quot;&gt;CartoDb&lt;/a&gt;, under  &lt;a href=&quot;https://creativecommons.org/licenses/by/3.0/&quot;&gt;CC BY 3.0 &lt;/a&gt;"  ></baselayer>
+    <baselayer visible="false" id="ortho_ign" thumbgallery="img/basemap/ortho.jpg" title="IGN" label="Photographies aériennes IGN" type="WMTS" url="https://wxs.ign.fr/choisirgeoportail/geoportail/wmts?" layers="ORTHOIMAGERY.ORTHOPHOTOS" format="image/jpeg" fromcapacity="false" attribution="&lt;a href='https://geoservices.ign.fr' target='_blank'&gt;&lt;img src='https://geoservices.ign.fr/images/logoIGN.png'&gt;&lt;/a&gt;" style="normal" matrixset="PM" maxzoom="22"  ></baselayer>
+</baselayers>
+<themes mini="false">
+    <theme id="education" url="https://kartenn.region-bretagne.fr/territoires/apps/default.xml" name="Renommage Education et formation" collapsed="true" icon="false" layersvisibility="all">
+    </theme>
+    <theme id="transport" url="https://kartenn.region-bretagne.fr/kartoviz/apps/region/transport/transports.xml" name="Transport (Région)" collapsed="true" icon="false" layersvisibility="none">
+    </theme>
+    <theme id="maritime" url="https://kartenn.region-bretagne.fr/kartoviz/apps/region/global/global.xml" name="Transport maritime" collapsed="true" icon="false" layersvisibility="default">
+    </theme>
+</themes>
+</config>

--- a/docs/doc_tech/config_topics.rst
+++ b/docs/doc_tech/config_topics.rst
@@ -150,7 +150,7 @@ Elément enfant de <themes>
 .. code-block:: xml
        :linenos:
 
-	<theme name=""  collapsed="" id="" url="" icon="" />
+	<theme name=""  collapsed="" id="" url="" icon="" url="" layersvisibility=""/>
 
 **Paramètres**
 
@@ -158,6 +158,10 @@ Elément enfant de <themes>
 * ``id`` :guilabel:`studio` : paramètre obligatoire de type texte qui affecte un identifiant unique interne à la thématique.
 * ``collapsed`` :guilabel:`studio` : paramètre optionnel de type booléen (true/false) qui précise si la thématique est fermée au démarrage de l'application. Pour que la thématique soit ouverte au démarrage, il faut choisir l'option **false**. Attention, il ne peut y avoir qu'une thématique ayant ce paramètre à false. Valeur par défaut **true**.
 * ``icon`` :guilabel:`studio` : paramètre optionnel de type texte qui précise l'icône à utiliser afin d'illustrer la thématique. Les valeurs possibles sont à choisir parmi cette liste sur le site Fontawesome: https://fontawesome.com/v5/search?m=free. Une autre possibilité est d'uliser une classe css personnelle mobilisant une image. Il faut alors mettre la classe précédée d'un point comme valeur. exemple ".mycustomicon".
+* ``url`` :guilabel:`studio` : paramètre optionnel de type url(URL vers fichier xml) qui permet de récupérer une thématique complète depuis un config.xml externe.
+* ``layersvisibility`` :guilabel:`studio` : paramètre optionnel (all/none/default) qui précise la visibilités des couches dans la thématique externe. Valeur par défaut **default**.
+
+
 Voici un exemple d'icone personnalisée :
 
 .. code-block:: css

--- a/docs/doc_tech/config_topics.rst
+++ b/docs/doc_tech/config_topics.rst
@@ -150,7 +150,7 @@ Elément enfant de <themes>
 .. code-block:: xml
        :linenos:
 
-	<theme name=""  collapsed="" id="" url="" icon="" url="" layersvisibility=""/>
+	<theme name=""  collapsed="" id="" icon="" url="" layersvisibility=""/>
 
 **Paramètres**
 

--- a/js/configuration.js
+++ b/js/configuration.js
@@ -191,8 +191,9 @@ var configuration = (function () {
       extraConf.toArray().forEach(function (theme) {
         var url = $(theme).attr("url");
         var id = $(theme).attr("id");
+        const external_overwrite = {"name": $(theme).attr("name"), "layersvisibility": $(theme).attr("layersvisibility") || "default"}
         var proxy = false;
-        if ($(conf).find("proxy").attr("url")) {
+        if ($(conf).find("proxy").attr("url") && $(conf).find("proxy").attr("url") != "") {
           proxy = $(conf).find("proxy").attr("url");
         }
         requests.push(
@@ -200,10 +201,20 @@ var configuration = (function () {
             url: mviewer.ajaxURL(url, proxy),
             crossDomain: true,
             themeId: id,
+            external_overwrite: external_overwrite,
             success: function (response, textStatus, request) {
               //Si thématique externe récupérée, on la charge dans la configuration courante
               var node = $(response).find("theme#" + this.themeId);
               if (node.length > 0) {
+                const theme_element = node[0];
+                //overwrite theme name and layers visiblility
+                theme_element.setAttribute("name", this.external_overwrite.name)
+                //overwrite layers visiblility
+                if (this.external_overwrite.layersvisibility == "all") {
+                  theme_element.querySelectorAll("layer").forEach(l => l.setAttribute("visible", "true"));
+                } else if (this.external_overwrite.layersvisibility == "none") {
+                  theme_element.querySelectorAll("layer").forEach(l => l.setAttribute("visible", "false"));
+                }
                 $(conf)
                   .find("theme#" + this.themeId)
                   .replaceWith(node);

--- a/js/configuration.js
+++ b/js/configuration.js
@@ -191,9 +191,15 @@ var configuration = (function () {
       extraConf.toArray().forEach(function (theme) {
         var url = $(theme).attr("url");
         var id = $(theme).attr("id");
-        const external_overwrite = {"name": $(theme).attr("name"), "layersvisibility": $(theme).attr("layersvisibility") || "default"}
+        const external_overwrite = {
+          name: $(theme).attr("name"),
+          layersvisibility: $(theme).attr("layersvisibility") || "default",
+        };
         var proxy = false;
-        if ($(conf).find("proxy").attr("url") && $(conf).find("proxy").attr("url") != "") {
+        if (
+          $(conf).find("proxy").attr("url") &&
+          $(conf).find("proxy").attr("url") != ""
+        ) {
           proxy = $(conf).find("proxy").attr("url");
         }
         requests.push(
@@ -208,12 +214,16 @@ var configuration = (function () {
               if (node.length > 0) {
                 const theme_element = node[0];
                 //overwrite theme name and layers visiblility
-                theme_element.setAttribute("name", this.external_overwrite.name)
+                theme_element.setAttribute("name", this.external_overwrite.name);
                 //overwrite layers visiblility
                 if (this.external_overwrite.layersvisibility == "all") {
-                  theme_element.querySelectorAll("layer").forEach(l => l.setAttribute("visible", "true"));
+                  theme_element
+                    .querySelectorAll("layer")
+                    .forEach((l) => l.setAttribute("visible", "true"));
                 } else if (this.external_overwrite.layersvisibility == "none") {
-                  theme_element.querySelectorAll("layer").forEach(l => l.setAttribute("visible", "false"));
+                  theme_element
+                    .querySelectorAll("layer")
+                    .forEach((l) => l.setAttribute("visible", "false"));
                 }
                 $(conf)
                   .find("theme#" + this.themeId)


### PR DESCRIPTION
### Cette PR permet de paramétrer une thématique externe.

**Paramétrages possibles**

- `name` : Nom de la thématique en remplacement du titre d'origine de la thématique
- `layersvisibility `: Affichage des couches composant la thématique ("all" / "none" / "default")

Démo avec demo/external.xml

Exemple de configuration 

```xml
<theme id="education"
     url="https://kartenn.region-bretagne.fr/territoires/apps/default.xml"
     name="Renommage Education et formation"
     layersvisibility="all">
</theme>
```