### PR TITLE
#757 Correction du plugin filtre avec des couches non visibles par défaut

### DIFF
--- a/demo/addons/filter/config.json
+++ b/demo/addons/filter/config.json
@@ -68,7 +68,8 @@
               {
                 "attribut": "dep",
                 "type": "button",
-                "label": "Départements"
+                "label": "Départements",
+                "updateOnChange": true
               },
               {
                 "attribut": "ville",
@@ -96,10 +97,10 @@
             "layerId": "commune",
             "filter": [
               {
-                "attribut": "nom_geo",
+                "attribut": "nom",
                 "type": "textbox",
                 "label": "Commune",
-                "updateOnChange": false
+                "updateOnChange": true
               }
             ]
           }

--- a/demo/filter/filter.xml
+++ b/demo/filter/filter.xml
@@ -25,7 +25,7 @@
         <layer id="structures"
             toplayer="true"
             name="Sites pour l'aide économique et l'innovation"
-            visible="true"
+            visible="false"
             url="demo/filter/customlayers/structures.js"
             queryable="true"
             type="customlayer"


### PR DESCRIPTION
Type : Correctif issue #757 

# Description

Auparavant, le comportement était que le plugin se rechargeait toutes les 3000 ms si la feature n'a aucune donnée. La couche n'étant pas chargée, les données n'était jamais disponible jusqu'à ce qu'elle soit rendu visible.

Cette PR permet donc de recharger les données lorsqu'une couche qui doit être filtrée, n'est pas chargée (au sens visible) à l'ouverture de la carte.

Le clic sur la couche pour la rendre visible va alors intégrer les données dans le plugin filtre pour afficher les filtres attributaires correspondants et recharger le panel du plugin.
