### PR TITLE
Option coordinates en degré décimaux

### DIFF
--- a/docs/doc_tech/config_app.rst
+++ b/docs/doc_tech/config_app.rst
@@ -33,6 +33,7 @@ Syntaxe
 		stats=""
 		statsurl=""
 		coordinates=""
+		coordinatestype=""
 		geoloc=""
 		mouseposition=""
 		togglealllayersfromtheme=""
@@ -69,7 +70,8 @@ Paramètres secondaires
 * ``iconhelp`` :guilabel:`studio` : paramètre optionnel de type texte qui précise l'icône à utiliser afin d'illustrer la thématique. Le nom de l'icône doit être renseigné sous cette forme fab fa-apple ou fas fa-mobile. Les valeurs possibles sont à choisir parmi cette liste (cliquez sur l'icône souhaité pour obtenir la syntaxe) sur le site Fontawesome : https://fontawesome.com/v5/search?m=free
 * ``stats``: paramètre optionnel de type booléen (true/false) activant l'envoi de stats d'utilisation l'application. Valeur par défaut **false**.
 * ``statsurl``: paramètre optionnel de type url précisant l'url du service reccueillant les données d'utilisation de l'application (ip, application title, date). Ce service n'est pas proposé dans mviewer.
-* ``coordinates`` :guilabel:`studio` : paramètre optionnel de type booléen (true/false) activant l'affichage des coordonnées GPS ( navbar) lors de l'interrogation. Valeur par défaut **false**.
+* ``coordinates`` :guilabel:`studio` : paramètre optionnel de type booléen (true/false) activant l'affichage des coordonnées GPS en degrés décimaux ( navbar) lors de l'interrogation. Valeur par défaut **false**.
+* ``coordinatestype``: paramètre optionnel de type texte permettant de modifier l'unité des coordonnées affichés grâce à l'option coordinate. La valeur dms permet afficher les coordonnées en degrés sexagésimale (degré minute seconde). 
 * ``geoloc`` :guilabel:`studio` : paramètre optionnel de type booléen (true/false) activant la géolocalisation. Nécessite une connection **https**. Valeur par défaut **false**.
 * ``mouseposition`` :guilabel:`studio` : paramètre optionnel de type booléen (true/false) activant l'affichage des coordonnées correspondant à la position de la souris. Les coordonnées sont affichées en bas à droite de la carte. Valeur par défaut **false**.
 * ``togglealllayersfromtheme`` :guilabel:`studio` : Ajoute un bouton dans le panneau de gauche pour chaque thématique afin d'afficher/masquer toutes les couches de la thématique.Valeur : true/false. Valeur par défaut **false**.

--- a/js/configuration.js
+++ b/js/configuration.js
@@ -16,6 +16,8 @@ var configuration = (function () {
 
   var _captureCoordinates = false;
 
+  var _typecoordinate= "";
+
   var _lang = false;
 
   var _languages = [];
@@ -382,6 +384,11 @@ var configuration = (function () {
     }
     if (conf.application.coordinates === "true") {
       _captureCoordinates = true;
+	  if(conf.application.coordinatestype === "dms"){
+	  _typecoordinate = "dms";
+	  } else {
+	  _typecoordinate = "xy";
+	  }
     }
     if (conf.application.togglealllayersfromtheme === "true") {
       _toggleAllLayersFromTheme = true;
@@ -1211,6 +1218,9 @@ var configuration = (function () {
     },
     getCaptureCoordinates: function () {
       return _captureCoordinates;
+    },
+    getTypeCoordinates: function () {
+      return _typecoordinate;
     },
     getConfiguration: function () {
       return _configuration;

--- a/js/configuration.js
+++ b/js/configuration.js
@@ -384,10 +384,10 @@ var configuration = (function () {
     }
     if (conf.application.coordinates === "true") {
       _captureCoordinates = true;
-	  if(conf.application.coordinatestype === "dms"){
-	  _typecoordinate = "dms";
-	  } else {
-	  _typecoordinate = "xy";
+      if(conf.application.coordinatestype === "dms"){
+        _typecoordinate = "dms";
+      } else {
+        _typecoordinate = "xy";
 	  }
     }
     if (conf.application.togglealllayersfromtheme === "true") {

--- a/js/configuration.js
+++ b/js/configuration.js
@@ -384,7 +384,7 @@ var configuration = (function () {
     }
     if (conf.application.coordinates === "true") {
       _captureCoordinates = true;
-	  _typecoordinate = conf.application.coordinatestype || "xy";
+      _typecoordinate = conf.application.coordinatestype || "xy";
     }
     if (conf.application.togglealllayersfromtheme === "true") {
       _toggleAllLayersFromTheme = true;

--- a/js/configuration.js
+++ b/js/configuration.js
@@ -16,7 +16,7 @@ var configuration = (function () {
 
   var _captureCoordinates = false;
 
-  var _typecoordinate= "";
+  var _typecoordinate = "";
 
   var _lang = false;
 
@@ -384,11 +384,11 @@ var configuration = (function () {
     }
     if (conf.application.coordinates === "true") {
       _captureCoordinates = true;
-      if(conf.application.coordinatestype === "dms"){
+      if (conf.application.coordinatestype === "dms") {
         _typecoordinate = "dms";
       } else {
         _typecoordinate = "xy";
-	  }
+      }
     }
     if (conf.application.togglealllayersfromtheme === "true") {
       _toggleAllLayersFromTheme = true;

--- a/js/configuration.js
+++ b/js/configuration.js
@@ -384,11 +384,7 @@ var configuration = (function () {
     }
     if (conf.application.coordinates === "true") {
       _captureCoordinates = true;
-      if (conf.application.coordinatestype === "dms") {
-        _typecoordinate = "dms";
-      } else {
-        _typecoordinate = "xy";
-      }
+	  _typecoordinate = conf.application.coordinatestype || "xy";
     }
     if (conf.application.togglealllayersfromtheme === "true") {
       _toggleAllLayersFromTheme = true;

--- a/js/info.js
+++ b/js/info.js
@@ -48,6 +48,7 @@ var info = (function () {
   var _clickCoordinates = null;
 
   var _captureCoordinatesOnClick = false;
+  var _typeCoordinates = "";
 
   /**
    * Property: _toolEnabled
@@ -164,13 +165,20 @@ var info = (function () {
     if (!_mvReady) {
       return False;
     }
-    if (_captureCoordinatesOnClick) {
+    if (_captureCoordinatesOnClick && _typeCoordinates === "dms") {
       var hdms = ol.coordinate.toStringHDMS(
         ol.proj.transform(evt.coordinate, _projection.getCode(), "EPSG:4326")
       );
       var hdms2 = hdms.replace(/ /g, "").replace("N", "N - ");
       $("#coordinates span").text(hdms2);
     }
+    if (_captureCoordinatesOnClick && _typeCoordinates === "xy") {
+      var hdms = ol.coordinate.toStringXY(
+        ol.proj.transform(evt.coordinate, _projection.getCode(), "EPSG:4326"),5
+      );
+      $("#coordinates span").text(hdms);
+    }
+
     //Request vector layers
     if (queryType === "map") {
       var pixel = evt.pixel;
@@ -1069,6 +1077,7 @@ var info = (function () {
     _projection = mviewer.getProjection();
     _overLayers = mviewer.getLayers();
     _captureCoordinatesOnClick = configuration.getCaptureCoordinates();
+    _typeCoordinates = configuration.getTypeCoordinates();
     _tocsortedlayers = $(".mv-nav-item")
       .map(function () {
         return $(this).attr("data-layerid");

--- a/js/info.js
+++ b/js/info.js
@@ -165,21 +165,15 @@ var info = (function () {
     if (!_mvReady) {
       return False;
     }
-    if (_captureCoordinatesOnClick && _typeCoordinates === "dms") {
-      var hdms = ol.coordinate.toStringHDMS(
-        ol.proj.transform(evt.coordinate, _projection.getCode(), "EPSG:4326")
-      );
-      var hdms2 = hdms.replace(/ /g, "").replace("N", "N - ");
-      $("#coordinates span").text(hdms2);
-    }
-    if (_captureCoordinatesOnClick && _typeCoordinates === "xy") {
-      var hdms = ol.coordinate.toStringXY(
-        ol.proj.transform(evt.coordinate, _projection.getCode(), "EPSG:4326"),
-        5
-      );
+    if (_captureCoordinatesOnClick && _typeCoordinates) {
+      const coordAsText = _typeCoordinates === "dms" ? ol.coordinate.toStringHDMS : ol.coordinate.toStringXY;
+      const coordPrec = _typeCoordinates === "dms" ? 0 : 5;
+      let hdms = coordAsText(
+        ol.proj.transform(evt.coordinate, _projection.getCode(), "EPSG:4326"),coordPrec
+      );  
+      hdms = _typeCoordinates === "xy" ? hdms : hdms.replace(/ /g, "").replace("N", "N - ");
       $("#coordinates span").text(hdms);
     }
-
     //Request vector layers
     if (queryType === "map") {
       var pixel = evt.pixel;

--- a/js/info.js
+++ b/js/info.js
@@ -166,12 +166,17 @@ var info = (function () {
       return False;
     }
     if (_captureCoordinatesOnClick && _typeCoordinates) {
-      const coordAsText = _typeCoordinates === "dms" ? ol.coordinate.toStringHDMS : ol.coordinate.toStringXY;
+      const coordAsText =
+        _typeCoordinates === "dms"
+          ? ol.coordinate.toStringHDMS
+          : ol.coordinate.toStringXY;
       const coordPrec = _typeCoordinates === "dms" ? 0 : 5;
       let hdms = coordAsText(
-        ol.proj.transform(evt.coordinate, _projection.getCode(), "EPSG:4326"),coordPrec
-      );  
-      hdms = _typeCoordinates === "xy" ? hdms : hdms.replace(/ /g, "").replace("N", "N - ");
+        ol.proj.transform(evt.coordinate, _projection.getCode(), "EPSG:4326"),
+        coordPrec
+      );
+      hdms =
+        _typeCoordinates === "xy" ? hdms : hdms.replace(/ /g, "").replace("N", "N - ");
       $("#coordinates span").text(hdms);
     }
     //Request vector layers

--- a/js/info.js
+++ b/js/info.js
@@ -174,7 +174,8 @@ var info = (function () {
     }
     if (_captureCoordinatesOnClick && _typeCoordinates === "xy") {
       var hdms = ol.coordinate.toStringXY(
-        ol.proj.transform(evt.coordinate, _projection.getCode(), "EPSG:4326"),5
+        ol.proj.transform(evt.coordinate, _projection.getCode(), "EPSG:4326"),
+        5
       );
       $("#coordinates span").text(hdms);
     }


### PR DESCRIPTION
Issue #730 

Proposition de PR (la doc sera complétée avant validation) : 
- par défaut si coordinates = "true" on affiche les degré décimaux
- si certains désirent les coordonnées en degrés minutes secondes , ajout d'une option coordinatestype="dms"

J'ai fait le choix de passer par défaut en décimaux qui semble le besoin des utilisateurs et de permettre à ceux qui veulent du dms de l'avoir avec une option en plus.