### PR TITLE
[Filter] #845 - download et dataSeparator

### DIFF
--- a/demo/addons/filter/js/filter.js
+++ b/demo/addons/filter/js/filter.js
@@ -1,4 +1,4 @@
-var filter = (function () {
+const filter = (function () {
   /**
    * Property: _id
    * @type {String}
@@ -310,19 +310,19 @@ var filter = (function () {
    **/
   var _getFilter = function (layerId) {
     let filterTxt;
-    filter.layersFiltersParams.get(layerId).forEach(function (filter, index, array) {
+    filter.layersFiltersParams.get(layerId).forEach((layerFilter) => {
       // Only if there is a filter
-      if (filter.currentValues.length > 0) {
-        let newFilter = filter.attribut + "='" + filter.currentValues[0] + "'";
-        if (filterTxt && filterTxt.length > 0) {
+      if (layerFilter.currentValues.length) {
+        const newFilter = `${layerFilter.attribut} LIKE '%${layerFilter.currentValues[0]}%'`;
+        if (filterTxt && filterTxt.length) {
           filterTxt += " AND " + newFilter;
         } else {
           filterTxt = newFilter;
         }
       }
     });
-    if (filterTxt && filterTxt.length > 0) {
-      return "&CQL_FILTER=" + filterTxt;
+    if (filterTxt && filterTxt.length) {
+      return "&CQL_FILTER=" + encodeURIComponent(filterTxt);
     } else {
       return "";
     }

--- a/demo/addons/filter/js/filter.js
+++ b/demo/addons/filter/js/filter.js
@@ -188,7 +188,7 @@ var filter = (function () {
       var destinationDivId = "advancedFilter-" + layerId;
 
       // Create div only if not exist
-      if (!$("#" + destinationDivId).length && nbLayers > 1) {
+      if (!$("#" + destinationDivId).length) {
         // add selectBox if needed
         const selected = mviewer.getLayer(layerId)?.layer.getVisible() ? "selected" : "";
         contentSelectLayer.push(


### PR DESCRIPTION
Cette PR corrige l'issue #845 en remplaçant l'opérateur CQL "=" par "LIKE" afin d'avoir un export des données dont la valeur contient le filtre.

Attention, cette PR ne permet pas d'avoir uniquement les features dont la valeur est strictement égale.
Il faudrait une évolution pour renseigner l'opérateur qui doit être appliqué dans le cas d'un champ avec séparateur type : 

`{"public": "jeunes,adultes,enfants"}`