### PR TITLE
Page erreur - voir le xml ou recharger

### DIFF
--- a/pages/error_400.html
+++ b/pages/error_400.html
@@ -92,6 +92,15 @@
     }
   }
 
+  .actions-div button{
+   background-color: white; 
+   border-radius: 20px;
+   border: 1px solid #455a64;
+   width: 35%;
+   height: 50px;
+   margin-top: 20px;
+   padding: 5px;
+  }
 
   </style>
 </head>
@@ -105,17 +114,31 @@
 		<div class="title">Oops !</div>
     <div class="sub text">Il semble y avoir un problème avec le mviewer.</div>
     <div id="message" class="text">Le fichier de configuration de l'application est incorrect.</div>
+    <div class="actions-div">
+      <button id="reload" type="button" class="btn btn-default" aria-label="Left Align">
+        <i class="fas fa-sync-alt"></i> Recharger la carte
+      </button>
+      <button id="goxml" type="button" class="btn btn-default" aria-label="Left Align">
+        <i class="far fa-eye"></i> Voir le XML
+      </button>
+    </div>
   </div>
   <script>
+    const url = new URL(window.location.href);
+    const xml = url.searchParams.get("xml");
     var message = "Le fichier de configuration de l'application";
-    var url_params = JSON.parse('{"' + decodeURIComponent(window.location.search.substring(1).replace(/&/g, "\",\"").replace(/=/g,"\":\"")) + '"}');
-    if (url_params.xml) {
-      message += ` - ${url_params.xml} - est incorrect.`;
-
-    } else {
-      message += ' est incorrect.';
-    }
+    message += xml ? ` - ${xml} - est incorrect.` : ' est incorrect.';
+    
     document.getElementById("message").textContent = message;
+
+    document.querySelector("#reload").addEventListener("click", x => {
+      const newUrl = window.location.protocol + "//" + window.location.host + "?config=" + xml;
+      window.location.href = newUrl;
+    })
+    document.querySelector("#goxml").addEventListener("click", x => {
+      const newUrl = `${window.location.protocol}//${window.location.host}/${xml}`;
+      window.location.href = newUrl;
+    })
   </script>
 </body>
 </html>

--- a/pages/error_404.html
+++ b/pages/error_404.html
@@ -3,6 +3,8 @@
   <meta charset='UTF-8'>
   <title>Error 404</title>
   <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,900;1,400&display=swap" rel="stylesheet">
+  <link href="../lib/font-awesome-5.13.0/css/all.min.css" rel="stylesheet" />
+
 
   <style type="text/css">
 
@@ -92,6 +94,15 @@
     }
   }
 
+  .actions-div button{
+   background-color: white; 
+   border-radius: 20px;
+   border: 1px solid #455a64;
+   width: 35%;
+   height: 50px;
+   margin-top: 20px;
+   padding: 5px;
+  }
 
   </style>
 </head>
@@ -105,17 +116,31 @@
 		<div class="title">Oops !</div>
     <div class="sub text">Il semble y avoir un problème avec le mviewer.</div>
     <div id="message" class="text"></div>
+    <div class="actions-div">
+      <button id="reload" type="button" class="btn btn-default" aria-label="Left Align">
+        <i class="fas fa-sync-alt"></i> Recharger la carte
+      </button>
+      <button id="goxml" type="button" class="btn btn-default" aria-label="Left Align">
+        <i class="far fa-eye"></i> Voir le XML
+      </button>
+    </div>
   </div>
   <script>
+    const url = new URL(window.location.href)
+    const xml = url.searchParams.get("xml");
     var message = "L'application n'existe pas (fichier de configuration introuvable";
-    var url_params = JSON.parse('{"' + decodeURIComponent(window.location.search.substring(1).replace(/&/g, "\",\"").replace(/=/g,"\":\"")) + '"}');
-    if (url_params.xml) {
-      message += ` : ${url_params.xml}).`;
-
-    } else {
-      message += ').';
-    }
+    message += xml ? ` : ${xml}).` : ').';
+    
     document.getElementById("message").textContent = message;
+
+    document.querySelector("#reload").addEventListener("click", x => {
+      const newUrl = window.location.protocol + "//" + window.location.host + "?config=" + xml;
+      window.location.href = newUrl;
+    })
+    document.querySelector("#goxml").addEventListener("click", x => {
+      const newUrl = `${window.location.protocol}//${window.location.host}/${xml}`;
+      window.location.href = newUrl;
+    })
   </script>
 </body>
 </html>


### PR DESCRIPTION
Permet d'ajouter 2 boutons pour voir le XML ou le recharger.
Cela évite de devoir ressaisir le XML quand on tombe sur la page d'erreur et on conserve cette belle page.