### PR TITLE
Time calendar - afficher les dates disponibles

### DIFF
--- a/css/mviewer.css
+++ b/css/mviewer.css
@@ -2028,3 +2028,8 @@ div#login-box {
 }
 
 
+.datepicker table tbody tr td.disabled {
+  color: rgba(119,119,119,0.2);
+  pointer-events: none;
+}
+

--- a/docs/doc_tech/config_layers.rst
+++ b/docs/doc_tech/config_layers.rst
@@ -171,6 +171,7 @@ Paramètres pour gérer la dimension temporelle des couches WMS
 * ``timevalues``: Valeurs temporelles séparées par des virgules. À utiliser avec le controle slider pour des valeurs non régulières ex (1950, 1976, 1980, 2004).
 * ``timemin``: Date mini format : "yyyy-mm-dd".
 * ``timemax``: Date maxi format : "yyyy-mm-dd".
+* ``timeshowavailable``: Booléen pour n'afficher dans le calendrier que les dates disponibles fournies par le getCapabilities (à utiliser avec le type `calendar` uniquement)
 
 Paramètres pour gérer le filtre attributaire (liste déroulante) des couches WMS
 ===================================================================================

--- a/js/configuration.js
+++ b/js/configuration.js
@@ -745,6 +745,7 @@ var configuration = (function () {
               oLayer.timeinterval = layer.timeinterval || "day";
             }
             oLayer.timecontrol = layer.timecontrol || "calendar";
+            oLayer.timeshowavailable = layer.timeshowavailable === "true";
             if (layer.timevalues && layer.timevalues.search(",")) {
               oLayer.timevalues = layer.timevalues.split(",");
             }

--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -2626,6 +2626,20 @@ mviewer = (function () {
       if (sessionStorage.getItem(_service_url))
         $("#user").val(sessionStorage.getItem(_service_url).split(":")[0]);
     },
+
+    /**
+     *
+     * @param {object} layer mviewer layer
+     * @returns
+     */
+    activeCalendar: (layerid, options) => {
+      $("#" + layerid + "-layer-timefilter")
+        .closest("div")
+        .append(
+          '<span class="input-group-addon"><i class="glyphicon glyphicon-th"></i></span>'
+        )
+        .datepicker(options);
+    },
     /**
      * Public Method: add Layer in legend
      *
@@ -2890,6 +2904,8 @@ mviewer = (function () {
 
       //Time Filter calendar
       if (layer.timefilter && layer.timecontrol === "calendar") {
+        let getCapRequestUrl = getCapUrl(layer.url);
+        let datesToDisplay = [];
         var options = {
           format: "yyyy-mm-dd",
           language: "fr",
@@ -2897,6 +2913,28 @@ mviewer = (function () {
           minViewMode: 0,
           autoclose: true,
         };
+        if (layer.timeshowavailable) {
+          const dateFormat = "DD/MM/YYYY";
+          options.beforeShowDay = (day) => {
+            const isEnabled = datesToDisplay.includes(moment(day).format(dateFormat));
+            return { enabled: isEnabled };
+          };
+          fetch(getCapRequestUrl)
+            .then((x) => x.text())
+            .then((z) => {
+              const reader = new ol.format.WMSCapabilities();
+              const capa = reader.read(z);
+              const layer = _.find(_.get(capa, "Capability.Layer.Layer"), [
+                "Name",
+                "humidite_bzh",
+              ]);
+              const timeValues = _.find(layer.Dimension, [
+                "name",
+                "time",
+              ])?.values?.split?.(",");
+              datesToDisplay = timeValues.map((time) => moment(time).format(dateFormat));
+            });
+        }
         if (layer.timemin && layer.timemax) {
           options.startDate = new Date(layer.timemin);
           options.endDate = new Date(layer.timemax);
@@ -2925,7 +2963,6 @@ mviewer = (function () {
             '<span class="input-group-addon"><i class="glyphicon glyphicon-th"></i></span>'
           )
           .datepicker(options);
-
         $("#" + layer.layerid + "-layer-timefilter").on("change", function (data, cc) {
           mviewer.setLayerTime(layer.layerid, data.currentTarget.value);
         });


### PR DESCRIPTION
> ref #870 

Cette PR permet de mettre en surbrillance les dates disponibles (publiées par la dimension temps) et permet de ne sélectionner que celles-ci.

Pour que ce mode de visualisation soit optionnel, un nouveau paramètre `timeshowavailable` a été ajouté.

![image](https://github.com/mviewer/mviewer/assets/16317988/91905b55-1208-4f42-b2d8-f26e4aafa984)


Contenu :
- [x] code
- [x] documentation
