### PR TITLE
Switch docker image to NGINX unprivileged

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine
+FROM nginxinc/nginx-unprivileged:alpine
 
 VOLUME ["/usr/share/nginx/html/apps"]
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ docker build -t mviewer/mviewer .
 # faire tourner le conteneur, et le rendre accessible sur le port 8080. A l'arret du
 # conteneur celui-ci est supprimé (option `--rm`):
 
-docker run --rm -p8080:80 -v$(pwd)/apps:/usr/share/nginx/html/apps mviewer/mviewer
+docker run --rm -p8080:8080 -v$(pwd)/apps:/usr/share/nginx/html/apps mviewer/mviewer
 ```
 
 Une fois le conteneur lancé, `mviewer` sera disponible sur `http://localhost:8080`.
@@ -104,7 +104,7 @@ mviewer dans un répertoire existant, vous pouvez le monter à la place de celui
 proposé par défaut par le dépot en utilisant l'option `-v` de docker comme suit:
 
 ```
-docker run --rm -p8080:80 -v/chemin/vers/repertoire_de_configurations_xml:/usr/share/nginx/html/apps mviewer/mviewer
+docker run --rm -p8080:8080 -v/chemin/vers/repertoire_de_configurations_xml:/usr/share/nginx/html/apps mviewer/mviewer
 ```
 
 La seule contrainte étant que le chemin doit être indiqué à docker de manière absolue.

--- a/docs/doc_tech/deploy.rst
+++ b/docs/doc_tech/deploy.rst
@@ -78,7 +78,7 @@ Ce mode ne convient pas pour effectuer ses propres applications mviewer.
     #Récupérer la dernière image buildée de mviewer
     docker pull mviewer/mviewer
     #Lancer le container docker mviewer
-    docker run --rm -p80:80 mviewer/mviewer
+    docker run --rm -p80:8080 mviewer/mviewer
 
 
 mviewer et un dossier d'applications
@@ -90,7 +90,7 @@ C'est la solution à privilégier pour créer ses propres applications. En paral
 
     # Lancer le container mviewer + le répertoire web apps qui pointe vers
     # /chemin/vers/repertoire_de_configurations_xml
-    docker run --rm -p80:80 \
+    docker run --rm -p80:8080 \
         -v/chemin/vers/repertoire_de_configurations_xml:/usr/share/nginx/html/apps \
         mviewer/mviewer
 
@@ -122,7 +122,7 @@ Cette solution permet de mettre en place les mêmes possibilités que la méthod
         container_name: mviewer
         build: .
         ports:
-          - "80:80"
+          - "80:8080"
         image: mviewer/mviewer
         volumes:
           - '${APPSPATH}:/usr/share/nginx/html/apps'


### PR DESCRIPTION
The benefit is having a rootless docker image because we don't need to run mviewer docker image with the root user.

Also, it allows in docker the ability to force mviewer running under another user ID to more easily share the permissions with mviewerstudio or any other programs.

See for more info: https://stackoverflow.com/questions/63108119/how-to-run-an-nginx-container-as-non-root