### PR TITLE
#764 masquer une couche et url courte

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 dist/*
 node*
 panels/*
-apps/*.json
+apps/*
 node*
 package-*

--- a/js/configuration.js
+++ b/js/configuration.js
@@ -368,7 +368,7 @@ var configuration = (function () {
     if (location.hash && !location.search) {
       $(".mv-title").attr("href", location.hash);
       $(".navbar-brand").attr("href", location.hash);
-    }   
+    }
     if (conf.application.showhelp === "true") {
       _showhelp_startup = true;
     }

--- a/js/configuration.js
+++ b/js/configuration.js
@@ -368,7 +368,7 @@ var configuration = (function () {
     if (location.hash && !location.search) {
       $(".mv-title").attr("href", location.hash);
       $(".navbar-brand").attr("href", location.hash);
-    }    
+    }   
     if (conf.application.showhelp === "true") {
       _showhelp_startup = true;
     }

--- a/js/configuration.js
+++ b/js/configuration.js
@@ -365,6 +365,10 @@ var configuration = (function () {
     if (conf.application.logo) {
       $(".mv-logo").attr("src", conf.application.logo);
     }
+    if (location.hash && !location.search) {
+      $(".mv-title").attr("href", location.hash);
+      $(".navbar-brand").attr("href", location.hash);
+    }    
     if (conf.application.showhelp === "true") {
       _showhelp_startup = true;
     }

--- a/js/templates.js
+++ b/js/templates.js
@@ -60,7 +60,7 @@ mviewer.templates.layerControl = `
             <span class="lock-icon glyphicon glyphicon-lock" aria-hidden="true"></span>
         </button>
         {{/secure_layer}}
-        <a href="#" class="mv-layer-remove" aria-label="close" onclick="mviewer.removeLayer(this)" title="Supprimer" i18n="theme.layers.remove">
+        <a href="${locationHref}" class="mv-layer-remove" aria-label="close" onclick="mviewer.removeLayer(this)" title="Supprimer" i18n="theme.layers.remove">
             <span class="glyphicon glyphicon-remove"></span>
         </a>
     </div>

--- a/js/templates.js
+++ b/js/templates.js
@@ -1,8 +1,7 @@
 var mviewer = mviewer || {};
 mviewer.templates = {};
 
-mviewer.templates.tooltip =
-`<div class="tooltip mv-tooltip" role="tooltip">
+mviewer.templates.tooltip = `<div class="tooltip mv-tooltip" role="tooltip">
     <div class="mv-tooltip tooltip-arrow"></div>
     <div class="mv-tooltip tooltip-inner popover-content"></div>
 </div>`;
@@ -193,7 +192,7 @@ mviewer.templates.layerControl = `
         <a href="#" aria-label="Options" onclick="mviewer.toggleLayerOptions(this);" title="Options" i18n="theme.layers.options" class="icon-options">
             <span class="state-icon glyphicon glyphicon-chevron-down"></span>
         </a>
-</li>`
+</li>`;
 
 mviewer.templates.backgroundLayerControlGallery = `
 <li data-original-title="{{label}}"
@@ -307,84 +306,84 @@ mviewer.templates.featureInfo.accordion = `
             </div>
         </div>
     </div>
-</div>;`
+</div>;`;
 
 mviewer.templates.featureInfo.accordion = [
-    '<div id="{{panel}}-selector">',
-        '<div class="row">',
-            '<div class="col-md-12">',
-                '<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true" style="list-style: none;">',
-                '{{#layers}}',
-                  '<div class="panel">',
-                    '<div class="panel-heading mv-theme caret-toggle {{^firstlayer}}collapsed{{/firstlayer}}" id="dataToggleDiv" data-toggle="collapse" data-parent="#accordion" href="#accordion-{{panel}}-{{id}}" role="tab" id="heading-{{panel}}-{{id}}" data-layerid="{{layerid}}">',
-                      '<h4 class="panel-title text-right">',
-                        '<a role="button" class="pull-left" aria-expanded="{{#firstlayer}}true{{/firstlayer}}{{^firstlayer}}false{{/firstlayer}}" aria-controls="accordion-{{panel}}-{{id}}">',
-                          '{{name}}',
-                         '</a>',
-                        '{{#firstlayer}}<span class="state-icon glyphicon firstLayer"></span>{{/firstlayer}}',
-                        '{{^firstlayer}}<span class="state-icon glyphicon notFirstLayer"></span>{{/firstlayer}}',
-                      '</h4>',
-                    '</div>',
-                    '<div id="accordion-{{panel}}-{{id}}" class="panel-collapse collapse {{#firstlayer}}in{{/firstlayer}}" role="tabpanel" aria-labelledby="heading-{{panel}}-{{id}}">',
-                      '<div class="panel-body">',
-                                '<div id="carousel-{{panel}}-{{id}}" div class="carousel slide" data-interval="false">',
-                            '<ul class="carousel-inner" role="listbox">',
-                            '{{{html}}}',
-                            '</ul>',
-                            '{{#manyfeatures}}',
-                                '<a class="left carousel-control" href="#carousel-{{panel}}-{{id}}" ',
-                                'role="button" data-slide="prev">',
-                                '<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>',
-                                '<span class="sr-only" i18n="carousel.control.previous">Previous</span>',
-                                '</a>',
-                                '<a class="right carousel-control" href="#carousel-{{panel}}-{{id}}" ',
-                                'role="button" data-slide="next">',
-                                '<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>',
-                                '<span class="sr-only" i18n="carousel.control.next">Next</span>',
-                                '</a>',
-                                '<span class="badge counter-slide">1/{{nbfeatures}}</span>',
-                            '{{/manyfeatures}}',
-                            '</div>',
-                      '</div>',
-                    '</div>',
-                  '</div>',
-                '{{/layers}}',
-                '</div>',
-            '</div>',
-        '</div>',
-    '</div>'
+  '<div id="{{panel}}-selector">',
+  '<div class="row">',
+  '<div class="col-md-12">',
+  '<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true" style="list-style: none;">',
+  "{{#layers}}",
+  '<div class="panel">',
+  '<div class="panel-heading mv-theme caret-toggle {{^firstlayer}}collapsed{{/firstlayer}}" id="dataToggleDiv" data-toggle="collapse" data-parent="#accordion" href="#accordion-{{panel}}-{{id}}" role="tab" id="heading-{{panel}}-{{id}}" data-layerid="{{layerid}}">',
+  '<h4 class="panel-title text-right">',
+  '<a role="button" class="pull-left" aria-expanded="{{#firstlayer}}true{{/firstlayer}}{{^firstlayer}}false{{/firstlayer}}" aria-controls="accordion-{{panel}}-{{id}}">',
+  "{{name}}",
+  "</a>",
+  '{{#firstlayer}}<span class="state-icon glyphicon firstLayer"></span>{{/firstlayer}}',
+  '{{^firstlayer}}<span class="state-icon glyphicon notFirstLayer"></span>{{/firstlayer}}',
+  "</h4>",
+  "</div>",
+  '<div id="accordion-{{panel}}-{{id}}" class="panel-collapse collapse {{#firstlayer}}in{{/firstlayer}}" role="tabpanel" aria-labelledby="heading-{{panel}}-{{id}}">',
+  '<div class="panel-body">',
+  '<div id="carousel-{{panel}}-{{id}}" div class="carousel slide" data-interval="false">',
+  '<ul class="carousel-inner" role="listbox">',
+  "{{{html}}}",
+  "</ul>",
+  "{{#manyfeatures}}",
+  '<a class="left carousel-control" href="#carousel-{{panel}}-{{id}}" ',
+  'role="button" data-slide="prev">',
+  '<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>',
+  '<span class="sr-only" i18n="carousel.control.previous">Previous</span>',
+  "</a>",
+  '<a class="right carousel-control" href="#carousel-{{panel}}-{{id}}" ',
+  'role="button" data-slide="next">',
+  '<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>',
+  '<span class="sr-only" i18n="carousel.control.next">Next</span>',
+  "</a>",
+  '<span class="badge counter-slide">1/{{nbfeatures}}</span>',
+  "{{/manyfeatures}}",
+  "</div>",
+  "</div>",
+  "</div>",
+  "</div>",
+  "{{/layers}}",
+  "</div>",
+  "</div>",
+  "</div>",
+  "</div>",
 ].join("");
 
 mviewer.templates.featureInfo.allintabs = [
-    '<div id="{{panel}}-selector">',
-        '<div class="row">',
-            '<div class="col-md-12">',
-                '<div class="tabs-left">',
-                    '<ul class="nav nav-tabs">',
-                    '{{#layers}}',
-                        '<li title="{{name}}" class="{{#firstlayer}}active{{/firstlayer}}" data-layerid="{{layerid}}" {{#initiallayerid}}initiallayerid="{{initiallayerid}}" {{/initiallayerid}}>',
-                            '<a onclick="mviewer.setInfoPanelTitle(this,\'{{panel}}\');" title="{{name}}" href="#slide-{{panel}}-{{id}}" data-toggle="tab">',
-                                '<span class="fa {{theme_icon}}"></span>',
-                                '{{#multiple}}<span class="item-number">{{index}}</spanclass>{{/multiple}}',
-                            '</a>',
-                        '</li>',
-                    '{{/layers}}',
-                    '</ul>',
-                    '<div class="tab-content">',
-                    '{{#layers}}',
-                        '<div  role="tabpanel" class="{{#firstlayer}}active in {{/firstlayer}}tab-pane" id="slide-{{panel}}-{{id}}" >',
-                            '<div id="carousel-{{panel}}-{{id}}" div class="carousel slide" data-interval="false">',
-                                '<ul class="carousel-inner" role="listbox">',
-                                '{{{html}}}',
-                                '</ul>',
-                            '</div>',
-                        '</div>',
-                    '{{/layers}}',
-                    '</div>',
-                 '</div>',
-            '</div>',
-        '</div>',
-    '</div>'
+  '<div id="{{panel}}-selector">',
+  '<div class="row">',
+  '<div class="col-md-12">',
+  '<div class="tabs-left">',
+  '<ul class="nav nav-tabs">',
+  "{{#layers}}",
+  '<li title="{{name}}" class="{{#firstlayer}}active{{/firstlayer}}" data-layerid="{{layerid}}" {{#initiallayerid}}initiallayerid="{{initiallayerid}}" {{/initiallayerid}}>',
+  '<a onclick="mviewer.setInfoPanelTitle(this,\'{{panel}}\');" title="{{name}}" href="#slide-{{panel}}-{{id}}" data-toggle="tab">',
+  '<span class="fa {{theme_icon}}"></span>',
+  '{{#multiple}}<span class="item-number">{{index}}</spanclass>{{/multiple}}',
+  "</a>",
+  "</li>",
+  "{{/layers}}",
+  "</ul>",
+  '<div class="tab-content">',
+  "{{#layers}}",
+  '<div  role="tabpanel" class="{{#firstlayer}}active in {{/firstlayer}}tab-pane" id="slide-{{panel}}-{{id}}" >',
+  '<div id="carousel-{{panel}}-{{id}}" div class="carousel slide" data-interval="false">',
+  '<ul class="carousel-inner" role="listbox">',
+  "{{{html}}}",
+  "</ul>",
+  "</div>",
+  "</div>",
+  "{{/layers}}",
+  "</div>",
+  "</div>",
+  "</div>",
+  "</div>",
+  "</div>",
 ].join("");
 
 mviewer.templates.ctrlSensor = `

--- a/js/templates.js
+++ b/js/templates.js
@@ -8,8 +8,7 @@ mviewer.templates.tooltip =
 </div>`;
 
 let locationHref = location.hash || "#";
-mviewer.templates.themeLayer = 
-`<li class="mv-nav-item" onclick="mviewer.toggleLayer(this);" data-layerid="{{layerid}}"">
+mviewer.templates.themeLayer = `<li class="mv-nav-item" onclick="mviewer.toggleLayer(this);" data-layerid="{{layerid}}"">
     <a href="${locationHref}" >
         <span class="state-icon far mv-unchecked"></span> {{title}}
         <input type="checkbox" class="hidden" value="false" >

--- a/js/templates.js
+++ b/js/templates.js
@@ -7,9 +7,10 @@ mviewer.templates.tooltip =
     <div class="mv-tooltip tooltip-inner popover-content"></div>
 </div>`;
 
-mviewer.templates.themeLayer = `
-<li class="mv-nav-item" onclick="mviewer.toggleLayer(this);" data-layerid="{{layerid}}"">
-    <a href="#" >
+let locationHref = location.hash || "#";
+mviewer.templates.themeLayer = 
+`<li class="mv-nav-item" onclick="mviewer.toggleLayer(this);" data-layerid="{{layerid}}"">
+    <a href="${locationHref}" >
         <span class="state-icon far mv-unchecked"></span> {{title}}
         <input type="checkbox" class="hidden" value="false" >
     </a>


### PR DESCRIPTION
Bonjour,

Voici une proposition de résolution de l'issue #764 

J'ai modifié le configuration.js pour que lorsqu'il y a un "raccourci" de créé dans le mviewer via le "#", il soit maintenu lors du clic sur le titre ou sur le logo.

J'ai modifié le template.js pour que de la même manière il soit maintenu quand il existe à l'affichage/masquage d'une couche.

J'ai également modifié le gitignore pour que les xml publiés dans le dossier apps ne soient pas pris en compte. Sachant que dans les fait j'utilise un lien symbolique entre le dossier apps et mes dossier apps/application de manière à bénéficier du raccourci tout en gérant tous les fichiers de l'application dans le dossier dédié.

D'avance merci pour votre retour sur la proposition !
Bonne journée,

Pascal