### PR TITLE
Issue-918 Fix la cohérence de zoom entre la séléction et la prévisualisation de la carte

### DIFF
--- a/docs/doc_tech/config_map.rst
+++ b/docs/doc_tech/config_map.rst
@@ -23,7 +23,8 @@ Syntaxe
         rotation=""
         scalebar=""
         scaleunits=""
-        scalesteps=""/>
+        scalesteps=""
+        extent=""/>
 
 
 Paramètres
@@ -39,6 +40,7 @@ Paramètres
 * ``scaleunits`` : paramètre optionnel de type texte pour préciser l'unité de mesure de l'échelle ("metric" par défaut)
 * ``scalesteps`` : paramètre optionnel de type texte pour préciser le nombre de pas de l'échelle ("2" par défaut).
 * ``scaletext`` : paramètre optionnel de type texte pour préciser si on souhaite afficher le texte au dessus d'une échelle en barre ("true" par défaut).
+* ``extent`` : paramètre optionnel de type texte pour surcharger le center et le zoom afin de garder la cohérence entre la sélection de la map et sa prévisualisation (est lui même surchargé par maxextent qui limite le déplacement de la carte en prévisualisation).
 
 Exemple
 -----------------
@@ -56,7 +58,8 @@ Exemple
               center="-161129,6140339"
               zoom="9"
               projextent="-20037508.342789244, -20037508.342789244, 20037508.342789244, 20037508.342789244"
-              maxextent="-550346.603653, 5975541.123222, -45250.720745, 6262944.349574" />
+              maxextent="-550346.603653, 5975541.123222, -45250.720745, 6262944.349574" 
+              extent="-550346.603653, 5975541.123222, -45250.720745, 6262944.349574"/>
 
 .. Tip::
    La carte dispose également d'un marker qui s'affiche au clic sur la carte. Il est possible de modifier ce marker via un paramétrage dans ":ref:`configsearch`".

--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -347,17 +347,21 @@ mviewer = (function () {
       }),
     });
 
-    var extent = ol.proj.transformExtent(
+    var extent = mapoptions.extent ?
+    ol.proj.transformExtent(
       mapoptions.extent.split(",").map(function (item) {
         return parseFloat(item);
       }),
       'EPSG:3857',
       mapoptions.projection
-    );
+    ) : null
     
-    _map.getView().fit(extent, { 
+    if(extent !== null) {
+      _map.getView().fit(extent, { 
       size: _map.getSize(),
-    });
+      });
+    }
+    
 
     const mapReadyEvent = new CustomEvent("map-ready", {
       detail: {

--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -347,6 +347,18 @@ mviewer = (function () {
       }),
     });
 
+    var extent = ol.proj.transformExtent(
+      mapoptions.extent.split(",").map(function (item) {
+        return parseFloat(item);
+      }),
+      'EPSG:3857',
+      mapoptions.projection
+    );
+    
+    _map.getView().fit(extent, { 
+      size: _map.getSize(),
+    });
+
     const mapReadyEvent = new CustomEvent("map-ready", {
       detail: {
         map: _map,

--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -347,21 +347,21 @@ mviewer = (function () {
       }),
     });
 
-    var extent = mapoptions.extent ?
-    ol.proj.transformExtent(
-      mapoptions.extent.split(",").map(function (item) {
-        return parseFloat(item);
-      }),
-      'EPSG:3857',
-      mapoptions.projection
-    ) : null
-    
-    if(extent !== null) {
-      _map.getView().fit(extent, { 
-      size: _map.getSize(),
+    var extent = mapoptions.extent
+      ? ol.proj.transformExtent(
+          mapoptions.extent.split(",").map(function (item) {
+            return parseFloat(item);
+          }),
+          "EPSG:3857",
+          mapoptions.projection
+        )
+      : null;
+
+    if (extent !== null) {
+      _map.getView().fit(extent, {
+        size: _map.getSize(),
       });
     }
-    
 
     const mapReadyEvent = new CustomEvent("map-ready", {
       detail: {


### PR DESCRIPTION
Gère une variable envoyé par mviewerstudio pour garder la cohérence entre la sélection et la prévisualisation de la carte.