### PR TITLE
#940 Fix loading with empty group

### DIFF
--- a/js/configuration.js
+++ b/js/configuration.js
@@ -99,11 +99,13 @@ var configuration = (function () {
         } else {
           theme.group = [];
         }
-        theme.group.forEach(function (group) {
-          if (!Array.isArray(group.layer)) {
-            group.layer = [group.layer];
-          }
-        });
+        theme.group
+          .filter((gp) => gp?.layer)
+          .forEach(function (group) {
+            if (!Array.isArray(group.layer)) {
+              group.layer = [group.layer];
+            }
+          });
         if (theme.layer) {
           if (!Array.isArray(theme.layer)) {
             theme.layer = [theme.layer];


### PR DESCRIPTION
> ref #940 

Cette PR contient le correctif pour charger la carte si un groupe ne contient pas de couches.