### PR TITLE
fix nohighlight param - #959

### DIFF
--- a/js/configuration.js
+++ b/js/configuration.js
@@ -834,7 +834,11 @@ var configuration = (function () {
             oLayer.dynamiclegend = layer.dynamiclegend === "true" ? true : false;
             oLayer.vectorlegend = layer.vectorlegend === "true" ? true : false;
             oLayer.nohighlight =
-              layer.type != "sensorthings" || layer.nohighlight === "true" ? true : false;
+              layer.type === "sensorthings"
+                ? "false"
+                : layer.nohighlight === "true"
+                ? true
+                : false;
             oLayer.infohighlight =
               layer.type === "sensorthings" || layer.infohighlight === "false"
                 ? false


### PR DESCRIPTION
Cette PR corrige le problème de lecture du paramètre nohighlight actuellement présent depuis la version 3.9 (depuis le sensorthings).