### PR TITLE
Ajout fonctionnalités de multilingue

### DIFF
--- a/docs/doc_tech/config_translate.rst
+++ b/docs/doc_tech/config_translate.rst
@@ -160,3 +160,54 @@ rajoutez les nouvelles clés dans votre fichier de traduction::
 5 - Eventuellement, choissisez d'afficher le sélecteur de langue dans la popup d'aide avec le paramètre *showhelp='true'*
 
 6 - Testez
+
+
+**Traduction du contenu dynamique**
+
+* Utilisez le paramètre debug_translation=true pour afficher les attributs i18n à ajouter dans votre dictionnaire: 
+    http://kartenn.region-bretagne.fr/kartoviz/?config=demo/lang.xml&debug_translation=true
+
+
+* Les attributs ci-dessous sont en commun par toutes cartes, et sont à ajouter dans votre fichier json:
+
+ * *loader.title* : Nom affiché lors du chargement de la carte
+ * *map_title* : Nom de la carte
+
+Les attributs des thèmes et les layers seront de la forme: *themes.id_généré* et *layers.id_généré*.
+
+
+Traduction des templates
+---------------------------------
+
+Mviewer propose, en option, de traduire les templates Mustache utilisés pour les fiche d'information. Vous pouvez donc appeler un template par langue, deux choix se présentent à vous :
+
+
+**1 - Appel des templates locaux**
+
+Renseignez le chemin du template de la manière suivante: 
+
+    *<template url=\"chemin/nom_du_template\" />*
+
+*Attention:* nom_du_template n'est pas un dossier, mais le préfixe commun entre vos fichiers templates.
+
+Par exemple si *lang='fr,de'*, mviewer va chercher les templates *chemin/nom_du_template_fr.mst* et *chemin/nom_du_template_en.mst*. Il faudra donc mettre la fiche d'information de chaque langue dans le fichier correspondant:
+::
+
+    chemin
+    ├── nom_du_template_fr.mst
+    ├── nom_du_template_de.mst
+    └── ...
+
+
+
+
+**2 - Appel des templates distants**
+
+Renseignez l'url des templates de la manière suivante: <template url=\"votre_url/exemple\"  />
+
+Mviewer fera donc appel à votre template distant en ajoutant le suffixe de la langue choisie comme paramètre.
+
+Exemple pour *lang='en,fr,bzh'*, 3 requêtes seront envoyées: 
+    *votre_url/exemple?lang=en* ; *votre_url/exemple?lang=fr* ; *votre_url/exemple?lang=bzh*
+
+

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
     <div id="loading-page">
       <div class="single4"></div>
       <div id="loader-title" i18n="loader.text">Chargement de l'application ...</div>
-      <div id="loader-subtitle"></div>
+      <div id="loader-subtitle" i18n="loader.title"></div>
     </div>
     <div id="error">
       <h1></h1>
@@ -112,7 +112,7 @@
           <a class="navbar-brand" href="#">
             <img alt="Logo" src="img/logo/earth-globe.svg" class="mv-logo" />
           </a>
-          <a class="navbar-brand mv-title" href="#">mViewer</a>
+          <a class="navbar-brand mv-title" href="#" i18n="map_title">mViewer</a>
           <a
             type="button"
             class="navbar-toggle"
@@ -173,6 +173,7 @@
                 data-toggle="dropdown"
                 role="button"
                 aria-expanded="true">
+                <span aria-setsize="20px" class="fa fa-language fa-lg"></span>
                 <span i18n="nav.down.lang">Langue</span>
                 <span class="caret"></span>
               </a>

--- a/js/configuration.js
+++ b/js/configuration.js
@@ -807,16 +807,79 @@ var configuration = (function () {
             }
             //Mustache template
             if (layer.template && layer.template.url) {
-              $.get(mviewer.ajaxURL(layer.template.url, _proxy), function (template) {
-                oLayer.template = template;
-              });
+              /* if there are multiple languages, the user then has 2 possibilities:
+                    a - provide a template local file for each language,
+                        + ie: directory/template_fr.mst, directory/template_en.mst
+                        + the given url will be directory/template
+                        + ie: directory/template?lang=fr
+                        + the given url will be directory/template
+                */
+
+              /* to implement this i will add template_{lang} field to the layer object
+                in any case, the system will try to find all the templates and save them in the layer properties
+                
+                */
+              var found = 0;
+              var languages = configuration.getLanguages();
+
+              // used jquery validator's url regex
+              var isUrl = (str) =>
+                str.match(
+                  /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g
+                ) !== null;
+
+              if (
+                configuration.getLang().length === 1 ||
+                layer.template.url.endsWith(".mst")
+              ) {
+                //NORMAL CASE, conditions: [mst extension at the end of the url]"
+                $.get(mviewer.ajaxURL(layer.template.url, _proxy), function (template) {
+                  oLayer.template = template;
+                  found = true;
+                });
+              } else {
+                if (isUrl(layer.template.url)) {
+                  // try with the api solution (b)
+                  languages.forEach(function (lang) {
+                    // check if you can get the template for this language
+                    var template_url_field_name = "template_" + lang;
+
+                    var template_url = new URL(layer.template.url);
+                    template_url.searchParams.set("lang", lang);
+                    template_url = template_url.toString();
+
+                    $.get(mviewer.ajaxURL(template_url, _proxy), function (template) {
+                      oLayer[template_url_field_name] = template;
+                      //console.log("added " + lang + " template through api");
+                      found++;
+                    }).fail(function () {
+                      console.log("failed to load " + lang + " template through api");
+                    });
+                  });
+                } else {
+                  languages.forEach(function (lang) {
+                    var template_url_field_name = "template_" + lang;
+                    var template_url = layer.template.url + "_" + lang + ".mst";
+
+                    $.get(mviewer.ajaxURL(template_url, _proxy), function (template) {
+                      oLayer[template_url_field_name] = template;
+                      //console.log("added " + lang + " template through filesystem");
+                      found++;
+                    }).fail(function () {
+                      console.log(
+                        "failed to load " + lang + " template through filesystem"
+                      );
+                    });
+                  });
+                }
+              }
             } else if (layer.template) {
               oLayer.template = layer.template;
             } else {
               oLayer.template = false;
             }
             oLayer.queryable = layer.queryable === "true" ? true : false;
-            oLayer.exclusive = layer.exclusive === "true" ? true : false;
+            oLayer.exclusive = layer.exclusive === "true" ? true : false;l
             oLayer.searchable = layer.searchable === "true" ? true : false;
             if (oLayer.searchable) {
               oLayer = search.configSearchableLayer(oLayer, layer);

--- a/js/info.js
+++ b/js/info.js
@@ -110,18 +110,70 @@ var info = (function () {
    * @param featurescount {Integer}
    *
    */
-  var _customizeHTML = function (html, featurescount) {
+  var _customizeHTML = function (
+    html,
+    featurescount,
+    lang_to_add = "",
+    template_is_mst_file = false
+  ) {
     //manipulate html to activate first item.
     var tmp = document.createElement("div");
     $(tmp).append(html);
-    $(tmp).find("li.item").first().addClass("active");
+    if (configuration.getLanguages().length > 1) {
+      // check if lang_to_add is defined and is in the list of languages
+      // if so add id that can be used by button to show the content
+      if (lang_to_add != "" && configuration.getLanguages().includes(lang_to_add)) {
+        // hide cluster_length first elements
+        $(tmp).find("li.item").slice(0, featurescount).addClass(`mst_${lang_to_add}`);
+      }
+
+      // hide all elements initially if immeadiate div child is not of class "gml-item"
+      if (
+        $(tmp).find("li.item").first().find("div").first().attr("class") != "gml-item"
+      ) {
+        if (!template_is_mst_file) {
+          $(tmp).find("li.item").hide();
+        }
+      }
+      $(tmp)
+        .find(`li.item.mst_${configuration.getLang()}`)
+        .slice(0, featurescount)
+        .css("display", "");
+      // do NOT use .show() as it will set display to something we dont want
+    }
+    $(tmp)
+      .find("li.item.mst_" + configuration.getLang())
+      .first()
+      .addClass("active");
+
+    // hide other languages slides
+    $(tmp)
+      .find("li.item")
+      .not(".mst_" + configuration.getLang())
+      .addClass("hidden-item")
+      .removeClass("item");
+
+    // if element is current language show it
+
     //manipulate html to add data-counter attribute to each feature.
     if (featurescount > 1) {
-      $(tmp)
-        .find("li.item")
-        .each(function (i, item) {
-          $(item).attr("data-counter", i + 1 + "/" + featurescount);
-        });
+      if (
+        configuration.getLanguages().length > 1 &&
+        lang_to_add !== "" &&
+        configuration.getLanguages().includes(lang_to_add)
+      ) {
+        $(tmp)
+          .find("li.item.mst_" + lang_to_add)
+          .each(function (i, item) {
+            $(item).attr("data-counter", i + 1 + "/" + featurescount);
+          });
+      } else {
+        $(tmp)
+          .find("li.item")
+          .each(function (i, item) {
+            $(item).attr("data-counter", i + 1 + "/" + featurescount);
+          });
+      }
     }
     return [$(tmp).html()];
   };
@@ -282,11 +334,29 @@ var info = (function () {
             var id = views[panel].layers.length + 1;
             //Create html content from features
             var html_result = "";
-            if (l.template) {
-              html_result = applyTemplate(features, l);
+            // check if l.template has a field other than url
+            if (Object.keys(l.template).some((key) => key !== "url")) {
+              // contains an  actual template not just url
+              html_result.push(applyTemplate(features, l));
             } else {
-              html_result = createContentHtml(features, l);
+              languages = configuration.getLanguages();
+              if (languages.length > 1) {
+                languages.forEach(function (lang) {
+                  var template_field_name = "template_" + lang;
+                  if (l[template_field_name]) {
+                    html_result.push(applyTemplate(features, l, lang));
+                  } else {
+                    html_result.push(createContentHtml(features, layerinfos));
+                  }
+                });
+              } else {
+                html_result.push(createContentHtml(features, l));
+              }
             }
+
+
+            // ***
+
             //Set view with layer info & html formated features
             views[panel].layers.push({
               panel: panel,
@@ -512,20 +582,66 @@ var info = (function () {
               _queriedFeatures.push.apply(_queriedFeatures, getFeatureInfo.features);
             }
             var features = getFeatureInfo.features;
+            var languages = configuration.getLanguages();
             if (features.length > 0) {
               if (_panelsTemplate[panel] == "allintabs") {
                 features.forEach(function (feature, index) {
-                  if (layerinfos.template) {
+                // check if l.template has a field other than url
+                if (Object.keys(layerinfos.template).some((key) => key !== "url")) {
+                // try to find .mst template file
                     html_result.push(applyTemplate([feature], layerinfos));
                   } else {
-                    html_result.push(createContentHtml([feature], layerinfos));
+                     // either used multiple langs or template doesnt exist
+                     if (languages.length > 1) {
+                      // multiple languages
+                      languages.forEach(function (lang) {
+                        var template_field_name = "template_" + lang;
+                        if (layerinfos[template_field_name]) {
+                          html_result.push(applyTemplate([feature], layerinfos, lang));
+                        } else if (
+                          // check if l.template has a field other than url
+                          Object.keys(layerinfos.template).some((key) => key !== "url")
+                        ) {
+                          // multiple languages but one mst template
+                          html_result.push(applyTemplate([feature], layerinfos));
+                        } else {
+                          // nothing found
+                          html_result.push(createContentHtml([feature], layerinfos));
+                        }
+                      });
+                    } else {
+                      // single language
+                      html_result.push(createContentHtml([feature], layerinfos));
+                    }
                   }
                 });
-              } else {
-                if (layerinfos.template) {
+              } // features from here on
+              else {
+                // check if l.template has a field other than url
+                if (Object.keys(layerinfos.template).some((key) => key !== "url")) {
+                  // try to find .mst template file
                   html_result.push(applyTemplate(features, layerinfos));
                 } else {
-                  html_result.push(createContentHtml(features, layerinfos));
+                   // either used multiple langs or template doesnt exist
+                   if (languages.length > 1) {
+                    // multiple languages
+                    languages.forEach(function (lang) {
+                      var template_field_name = "template_" + lang;
+                      if (layerinfos[template_field_name]) {
+                        html_result.push(applyTemplate(features, layerinfos, lang));
+                      } else if (
+                        Object.keys(layerinfos.template).some((key) => key !== "url")
+                      ) {
+                        // multiple languages but one mst template
+                        html_result.push(applyTemplate(features, layerinfos));
+                      } else {
+                        // nothing found
+                        html_result.push(createContentHtml(features, layerinfos));
+                      }
+                    });
+                  } else {
+                    html_result.push(createContentHtml(features, layerinfos));
+                  }
                 }
               }
             }
@@ -966,8 +1082,8 @@ var info = (function () {
    * @param olayer {mviewer.overLayer}
    */
 
-  var applyTemplate = function (olfeatures, olayer) {
-    var tpl = olayer.template;
+  var applyTemplate = function (olfeatures, olayer, lang = "") {
+    var tpl = olayer["template" + (lang == "" ? "" : "_" + lang)];
     var _json = function (str) {
       var result = null;
       try {
@@ -1041,7 +1157,9 @@ var info = (function () {
       obj.features.push({ ...feature.getProperties(), feature_ol_uid: feature.ol_uid });
     });
     var rendered = Mustache.render(tpl, obj);
-    return _customizeHTML(rendered, olfeatures.length);
+    var template_is_mst_file =
+    olayer.template && !olayer[`template_${lang}`] ? true : false;
+    return _customizeHTML(rendered, olfeatures.length, lang, template_is_mst_file);
   };
 
   /**

--- a/js/templates.js
+++ b/js/templates.js
@@ -9,7 +9,7 @@ mviewer.templates.tooltip = `<div class="tooltip mv-tooltip" role="tooltip">
 let locationHref = location.hash || "#";
 mviewer.templates.themeLayer = `<li class="mv-nav-item" onclick="mviewer.toggleLayer(this);" data-layerid="{{layerid}}"">
     <a href="${locationHref}" >
-        <span class="state-icon far mv-unchecked"></span> {{title}}
+        <span class="state-icon far mv-unchecked"></span> <div i18n="layers.{{layerid}}">{{title}}</div>
         <input type="checkbox" class="hidden" value="false" >
     </a>
 </li>`;
@@ -19,7 +19,7 @@ mviewer.templates.theme = `
     <a href="#">
         <span class="fa-stack fa-lg pull-left col-sm-3">
             <i class="{{icon}} fa-stack-1x "></i>
-        </span>{{name}}
+        </span><div i18n="themes.{{id}}">{{name}}</div>
     {{#toggleAllLayers}}
         <div class="toggle-theme-layers">
             <span class="badge" title="Afficher/Masquer toutes les couches de la thématique" i18n="theme.display.layers">0/1</span>


### PR DESCRIPTION
Bonjour,

Cette PR, refaite suite à l'utilisation de la mauvaise branche,  vise à compléter l'aspect multilingue de mviewer. Elle permet, à travers l'ajout d'un fichier de traduction json (format i18n), et d'un simple refactoring des fichiers templates (mst), de rendre une carte multilingue.

Cette contribution contient:
* L'ajout d'attributs i18n pour certains tags importants pour l'aspect multilingue:
    * index.html: loader subtitle, map title
    * templates.js: l'ajout des ids des thèmes et layers comme attribut i18n
* L'ajout d'une icone pour améliorer l'accessibilité aux options de langues, et l'affichage des langues dans leur propre langue native, d'ailleurs je recommande cette ressource pour future référence: [https://www.flagsarenotlanguages.com/blog/best-practice-for-presenting-languages/]
* Une refactorisation du cœur de l'application pour la prise en compte de la traduction des templates Mustache:
    * info.js: ajout de la classe mst_{langue} aux tags correspondants à la fiche d'infos de chaque langue, avec attribution de la classe hidden-item aux langues différentes de la langue d'affichage
    * mviewer.js:
        * séparation du showhelp du dropdown des langues, qui s'affiche maintenant dès que la page devient multilingue
        * changement du comportement de _elementTranslate au cas de traduction manquante dans d'autre langues mais présente dans une, avant: l'attribut i18n est affiché pour toutes les langues, meme celles avec une traduction du mot; après: la traduction fournie pour le langue est affichée indépendamment des autres langues. Un changement peut-etre subjectif mais que j'ai trouvé logique.
        * Aussi l'ajout du mode de débug pour aider l'utilisateur à savoir les attributs i18n à utiliser dans le dictionnaire de traduction, il s'agit d'un paramètre url debug_translation qui doit être mis à true
    * configuration.js: j'ai ajouté 2 modes d'accès aux templates de différentes langues, soit à travers une adresse url (j'avais utilisé un regex pour faire la vérification de lien, pas la meilleure méthode je trouve), soit en passant par les fichiers locaux (exemple: apps/titi/customcontrols/titi_en.mst,titi_fr.mst ...):
    *               /* if there are multiple languages, the user then has 2 possibilities:
                    a - provide a template local file for each language,
                        + ie: directory/template_fr.mst, directory/template_en.mst
                        + the given url will be directory/template
                    b - provide an api url that accepts the lang as a parameter
                        + ie: https://url.com/template?lang=fr
                        + the given url will be https://url.com/template
                */

* La documentation associée
* La prise en compte des affichages pour mobile
* Parfaitement rétro-compatible avec les cartes précédentes

Mehdi, pour GeoRhena

