### PR TITLE
Fix #983 print addon

### DIFF
--- a/demo/addons/print/js/print.js
+++ b/demo/addons/print/js/print.js
@@ -12,7 +12,7 @@ import ModalContent from "./components/ModalContent.js";
 import { getOptions } from "./components/Block.js";
 
 const onCloseModal = () => {
-  const btnClose = document.getElementById("print-panel-close");
+  const btnClose = document.getElementById("closePrintModal");
   btnClose.onclick = () => {
     document.querySelector("#mapBlock").remove();
     document.querySelector("#print-mapPrint").remove();

--- a/demo/addons/print/print.html
+++ b/demo/addons/print/print.html
@@ -11,6 +11,7 @@
         <button
           type="button"
           class="close"
+          id="closePrintModal"
           data-dismiss="modal"
         >&times;</button>
         <h3 class="modal-title">Imprimer la carte</h3>


### PR DESCRIPTION
# Description

Cette contribution contient un correctif pour l'addon print :

- Ajout d'un ID sur le bouton de fermeture de la modal
- Au clique sur le bouton, gérer la suppression des cartes pour conserver le correctif de #902 