### PR TITLE
#994 - Fix highlight selected features

### DIFF
--- a/js/info.js
+++ b/js/info.js
@@ -650,7 +650,7 @@ var info = (function () {
             var selectedFeature = _queriedFeatures.filter((feature) => {
               return feature.ol_uid == e.relatedTarget.id;
             });
-            if (!_.isEmpty(_queriedFeatures) && _queriedFeatures[0].get("features")) {
+            if (!_.isEmpty(_queriedFeatures) && !_queriedFeatures[0].get("features")) {
               mviewer.highlightSubFeature(selectedFeature[0]);
             }
           });

--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -2539,7 +2539,7 @@ mviewer = (function () {
      */
     highlightSubFeature: function (feature) {
       _sourceSubSelectOverlay.clear();
-      if (feature && typeof getGeometryName === "function") {
+      if (feature) {
         _sourceSubSelectOverlay.addFeature(feature);
       }
     },


### PR DESCRIPTION
> Reprise de la PR #996 vers develop et non master

> ref issue https://github.com/mviewer/mviewer/issues/994

Corrige les conditions pour la surbrillance des entités sélectionnées.

mviewer.js : highlightSubFeature() -> enlève la seconde condition qui bloque la condition (https://github.com/mviewer/mviewer/issues/995 en cours pour rétablir une condition fonctionnelle)

info.js l.653 : Corrige la seconde condition suite à modification.