### PR TITLE
#909 - Fermer l'outil de mesure avec la touche échappe

### DIFF
--- a/docs/doc_tech/config_app.rst
+++ b/docs/doc_tech/config_app.rst
@@ -60,7 +60,7 @@ Paramètres principaux
 * ``style`` :guilabel:`studio` : paramètre optionnel de type url précisant la feuille de style à utiliser afin de modifier l'apparence de l'application (couleurs, polices...). Valeur par défaut **css/themes/default.css**. Voir : ":ref:`configcss`".
 * ``exportpng`` :guilabel:`studio` : paramètre optionnel de type booléen (true/false) activant l'export de la carte en png. Valeur par défaut **false**. Attention l'export ne fonctionne qu'avec des couches locales (même origine) ou avec des couches servies avec  `CORS <https://enable-cors.org/>`_ activé.
 * ``mapprint`` :guilabel:`studio` : paramètre optionnel de type booléen (true/false) activant l'impression de la vue courante depuis le navigateur. Valeur par défaut **false**.
-* ``measuretools`` :guilabel:`studio` : paramètre optionnel de type booléen (true/false) activant les outils de mesure. Valeur par défaut **false**.
+* ``measuretools`` :guilabel:`studio` : paramètre optionnel de type booléen (true/false) activant les outils de mesure. Valeur par défaut **false**. Cet outil peut être également être fermé avec la touche `Esc`.
 * ``zoomtools`` :guilabel:`studio` : paramètre optionnel de type booléen (true/false) activant les outils de zoom +/-. Valeur par défaut **true**.
 * ``initialextenttool`` :guilabel:`studio` : paramètre optionnel de type booléen (true/false) activant le bouton de retour à l'étendue initiale. Valeur par défaut **true**.
 

--- a/js/measure.js
+++ b/js/measure.js
@@ -344,10 +344,25 @@ var measure = (function () {
   };
 
   /**
+   * Public Method: _createEscapeEvent
+   * used to create an event to close the measure tool
+   * when the escape key is pressed
+   */
+  var createEscapeEvent = () => {
+    document.addEventListener("keydown", function (event) {
+      if (event.key === "Escape") {
+        if (_modMeasureEnabled) {
+          console.log("escape");
+          mviewer.unsetTool("measure");
+        }
+      }
+    });
+  };
+
+  /**
    * _toggle. used to enable/disable this tool
    * public version of this method is toggle
    */
-
   var _toggle = function () {
     if (_modMeasureEnabled) {
       mviewer.unsetTool("measure");
@@ -403,6 +418,9 @@ var measure = (function () {
     $(buttonoptions).insertAfter("#toolstoolbar");
 
     _map.addLayer(vector);
+
+    // event to close the measure tool when the escape key is pressed
+    createEscapeEvent();
   };
 
   return {


### PR DESCRIPTION
> Ref #909 

Cette PR permet de fermer l'outil de mesure avec la touche échappe, si l'outil est ouvert et les boutons visibles.

@lecault peux-tu tester que ce comportement est bien celui que tu souhaites ?