### PR TITLE
Lire un CSV via son URL #1010

### DIFF
--- a/demo/addons/fileimport/README.md
+++ b/demo/addons/fileimport/README.md
@@ -92,3 +92,40 @@ Exemple qui rend disponible l'IHM de l'extension, permettant l'import `geojson`,
 ````
 
 L'IHM de l'import peut être accédé par le bouton du composant custom ou directement via l'arbre des couches.
+
+### Afficher un CSV renseigner dans l'URL
+
+Il est possible d'indiquer au mviewer de charger un CSV lors du premier chargement de la carte, sans aucune action de la part de l'utilisateur.
+
+Trois paramètres sont disponibles et à renseigner dans l'URL :
+
+- **xfield** : (option) Nom du champ dans le fichier CSV contenant la coordonnée X (longitude) 
+- **yfield** : (option) Nom du champ dans le fichier CSV contenant la coordonnée Y (latitude)
+- **file** : URL complète encodée du fichier CSV
+
+Exemple :
+
+https://monmviewer.fr?config=demo/csv.xml&file=https%3A%2F%2Fgrist.numerique.gouv.fr%2Fapi%2Fdocs%2F1HG28XWE7Ypy9eBJzper6N%2Fdownload%2Fcsv%3FtableId%3DTopologie_des_stations_le_velo_star&xfield=latitude&yfield=longitude
+
+Cet exemple contient 3 paramètres : 
+
+- **xfield** : latitude
+- **yfield** : longitude
+- **file** : https%3A%2F%2Fgrist.numerique.gouv.fr%2Fapi%2Fdocs%2F1HG28XWE7Ypy9eBJzper6N%2Fdownload%2Fcsv%3FtableId%3DTopologie_des_stations_le_velo_star
+
+Lors du partage de la carte, ces paramètres sont conserver dans le lien de partage.
+
+### Afficher un CSV à partir d'une URL via l'interface de chargement
+
+Plus haut, la description indique qu'il est possible de charger un fichier (import) depuis sont ordinateur.
+
+Il est également possible d'utiliser le champ "Charger un fichier" qui permettra de renseigner une URL de CSV à afficher sur la carte.
+
+Le fonctionnement avec les paramètres xfield et yfield reste identique :
+
+- si le CSV contient les champs renseignés dans la configuration (XML) de la couche, alors les données s'affichent sur la carte directement
+
+- si le CSV ne contient pas les champs renseignés, alors la fenêtre de configuration s'affiche pour indiquer les champs à utiliser pour localiser les données
+
+
+Lors du partage de la carte, les paramètres sont ajouter dans le lien de partage afin d'avoir affichées  lors du chargement de la carte à partir des paramètres d'URL.

--- a/demo/addons/fileimport/fileimport.js
+++ b/demo/addons/fileimport/fileimport.js
@@ -293,11 +293,7 @@ const fileimport = (function () {
 
           // call _mapCSV with parsed data
           if (oLayer.xfield && oLayer.yfield) {
-            _mapCSV(
-              data,
-              oLayer,
-              oLayer.layer
-            );
+            _mapCSV(data, oLayer, oLayer.layer);
           } else {
             _initCsvModal(idLayer, data, oLayer, "grist.csv");
           }

--- a/demo/addons/fileimport/fileimport.js
+++ b/demo/addons/fileimport/fileimport.js
@@ -827,7 +827,9 @@ const fileimport = (function () {
     // if fusesearch is enabled in config, 'change' event is fired and handled in the  _processSearchableLayer method (search.js)
     _source.addFeatures(features);
     // zoom to layer extent
-    utils.zoomToFeaturesExtent(_source.getFeatures());
+    if (l.getVisible()) {
+      utils.zoomToFeaturesExtent(_source.getFeatures());
+    }
     $("#csv-status").attr("class", "start");
     //draw layer Legend
     oLayer.legend = {
@@ -862,9 +864,9 @@ const fileimport = (function () {
         })
         .then((data) => {
           // insert url into layer prop to be shared in permalink
-          oLayer.layer.set("url", url);
+          oLayer.layer.set("url", oLayer.url);
           setPermaLink({
-            file: url,
+            file: oLayer.url,
           });
           // geocoding
           _geocode(data, oLayer, l);

--- a/demo/addons/fileimport/fileimport.js
+++ b/demo/addons/fileimport/fileimport.js
@@ -489,8 +489,8 @@ const fileimport = (function () {
         if ($("#collapseZero").hasClass("in") !== false) {
           oLayer.xfield = $("#x-select").val();
           oLayer.yfield = $("#y-select").val();
-          oLayer.layer.set(xfield, oLayer.xfield);
-          oLayer.layer.set(yfield, oLayer.yfield);
+          oLayer.layer.set("xfield", oLayer.xfield);
+          oLayer.layer.set("yfield", oLayer.yfield);
           _mapCSV(data, oLayer, oLayer.layer, $("#srs-select").val());
         } else {
           // geocode file

--- a/demo/addons/fileimport/fileimport.js
+++ b/demo/addons/fileimport/fileimport.js
@@ -5,6 +5,86 @@ const fileimport = (function () {
   var _srsHTML = ["<option value='EPSG:4326'>EPSG:4326</option>"];
 
   /**
+   * Private method createDefaultOLayerOption
+   * Creates default layer options for imported layers
+   * @param {*} idLayer
+   * @param {*} title
+   * @param {*} params
+   * @returns
+   */
+  const createDefaultOLayerOption = (idLayer, title, params) => {
+    let id = idLayer || _.uniqidId("import_file_");
+    return {
+      projections: {
+        projection: [
+          {
+            proj4js:
+              "'EPSG:3857','+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs'",
+          },
+          {
+            proj4js:
+              "'EPSG:2154','+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'",
+          },
+        ],
+      },
+      type: "import",
+      id: id,
+      name: title,
+      visible: "true",
+      legendurl: "img/blank.gif",
+      urlparam: "file",
+      queryable: true,
+      vectorlegend: true,
+      expanded: true,
+      sld: null,
+      template: false,
+      icon: "fas fa-file",
+      layername: id,
+      theme: "csv",
+      rank: 1,
+      index: null,
+      title: title,
+      layerid: id,
+      infospanel: "right-panel",
+      style: "",
+      toplayer: false,
+      draggable: true,
+      opacity: 1,
+      maxzoom: null,
+      minzoom: null,
+      tooltip: false,
+      tooltipenabled: false,
+      tooltipcontent: "",
+      timefilter: false,
+      timecontrol: "calendar",
+      timeshowavailable: false,
+      timemin: 2020,
+      timemax: 2025,
+      attributefilter: false,
+      attributeoperator: "=",
+      wildcardpattern: "%value%",
+      attributestylesync: false,
+      attributefilterenabled: false,
+      customcontrol: false,
+      customcontrolpath: "customcontrols",
+      exclusive: false,
+      searchable: false,
+      checked: true,
+      visiblebydefault: true,
+      tiled: false,
+      dynamiclegend: false,
+      nohighlight: false,
+      infohighlight: true,
+      showintoc: true,
+      useproxy: false,
+      jsonfields: [],
+      secure: "public",
+      authentification: false,
+      ...params,
+    };
+  };
+
+  /**
    * Private method _toggleImportLayer
    */
   var _toggleImportLayer = function () {
@@ -201,8 +281,8 @@ const fileimport = (function () {
    * Reads csv from URL and calls _initCsvModal with parsed data.
    * @param {*} idLayer
    */
-  const _loadUrlFile = function (idLayer) {
-    const url = document.getElementById("importFileByUrl").value;
+  const _loadUrlFile = function (idLayer, urlFromAPI) {
+    const url = urlFromAPI || document.getElementById("importFileByUrl").value;
     const oLayer = mviewer.getLayers()[idLayer];
     // read csv from URL
     fetch(url).then((response) => {
@@ -211,11 +291,16 @@ const fileimport = (function () {
           // parse csv to json
           console.log(data);
 
-          _initCsvModal(idLayer, data, oLayer, "grist.csv");
-
-          // var tmp = Papa.parse(data, { header: true });
-
           // call _mapCSV with parsed data
+          if (oLayer.xfield && oLayer.yfield) {
+            _mapCSV(
+              data,
+              oLayer,
+              oLayer.layer
+            );
+          } else {
+            _initCsvModal(idLayer, data, oLayer, "grist.csv");
+          }
           // _mapCSV(data, mviewer.getLayers()[idLayer], mviewer.getLayers()[idLayer].layer);
         });
       } else {
@@ -860,16 +945,47 @@ const fileimport = (function () {
       mviewer.alert(alertText + ": " + err.message, "alert-warning");
     }
   };
+  /*
+   * Private method _createLayerFromApi
+   * Creates layer from API file if URL param is available.
+   * Layer will be processed and added to map as native layer.
+   */
+  const _createLayerFromApi = () => {
+    if (API.file) {
+      // default oLayer params
+      let params = createDefaultOLayerOption(_.uniqueId(), "fichier csv", {
+        xfield: API?.xfield,
+        yfield: API?.yfield,
+      });
+      // create vector layer and add it to map
+      configuration.createVectorLayer(params, {
+        url: API.file,
+      });
+    }
+  };
+
   return {
     init: function () {
+      // Avoid to use existing XML layer. Allow to create a new one with default params.
+      _createLayerFromApi();
+
+      // parse layers and load data, or show wizard modal
       var layers = mviewer.getLayers();
+      let layerAPIToUse = null;
       for (var layer in layers) {
         if (layers[layer].type === "import") {
           var oLayer = layers[layer];
-          if (oLayer.url) {
-            _loadCSV(oLayer, oLayer.layer);
+          if (oLayer.urlparam && !oLayer?.geocoder) {
+            _loadUrlFile(oLayer.id, API.file);
+          } else if (oLayer.urlparam && oLayer?.geocoder) {
+            _loadCSV(oLayer, oLayer.layer, API.file);
+          } else if (oLayer.url && !oLayer?.geocoder === "BAN") {
+            _loadUrlFile(oLayer.id, oLayer.url);
+          } else if (oLayer.geocoder && oLayer.url) {
+            _loadCSV(oLayer, oLayer.layer, oLayer.url);
           } else {
             _initLoaderFile(oLayer);
+            layerAPIToUse = oLayer;
             _buttonActive = oLayer.visiblebydefault;
             _importLayer = oLayer;
             $(`.nav-pills [data-layerid=${oLayer.layerid}]`).on("click", function () {

--- a/demo/addons/fileimport/fileimport.js
+++ b/demo/addons/fileimport/fileimport.js
@@ -171,17 +171,61 @@ const fileimport = (function () {
    * HTML content of drag and drop zone
    */
   var _template = function (oLayer) {
-    return `<div class="dropzone dz-clickable" id="drop_zone" onclick="$('#loadcsv-${oLayer.layerid}').click();" ondrop="fileimport.dropHandler(event);" ondragover="fileimport.dragOverHandler(event);">
-                  <div id="csv-status" class="start">
-                      <div class="dz-default dz-message"><span class="fas fa-cloud-upload-alt fa-3x"></span>
-                          <p i18n="fileimport.upload.dropzone">Glisser un fichier GeoJSON, CSV ou SHP (en ZIP) ici ou clic pour sélectionner un fichier...</p>
-                      </div>
-                      <div class="dz-work dz-message"><span class="fas fa-spin fa-cog fa-3x"></span>
-                          <p i18n="fileimport.upload.processing">Traitement en cours</p>
-                      </div>
-                  </div>
-              </div>
-              <input type="file" name="filebutton" onchange="fileimport.loadLocalFile('${oLayer.layerid}')" style="visibility:hidden;" id="loadcsv-${oLayer.layerid}"/>`;
+    return `
+    <div class="form-group">
+      <label for="importFileByUrl">Charger un fichier via une URL</label>
+      <div class="input-group">
+        <input type="text" class="form-control" id="importFileByUrl" placeholder="http://example.com/file.csv">
+        <span class="input-group-btn">
+          <button class="btn btn-secondary" type="button" onclick="fileimport.loadUrlFile('${oLayer.layerid}')">Valider</button>
+        </span>
+      </div>
+    </div>
+    <label for="importFileByUrl">Téléverser un fichier</label>
+
+    <div class="dropzone dz-clickable" id="drop_zone" onclick="$('#loadcsv-${oLayer.layerid}').click();" ondrop="fileimport.dropHandler(event);" ondragover="fileimport.dragOverHandler(event);">
+        <div id="csv-status" class="start">
+            <div class="dz-default dz-message"><span class="fas fa-cloud-upload-alt fa-3x"></span>
+                <p i18n="fileimport.upload.dropzone">Glisser un fichier GeoJSON, CSV ou SHP (en ZIP) ici ou clic pour sélectionner un fichier...</p>
+            </div>
+            <div class="dz-work dz-message"><span class="fas fa-spin fa-cog fa-3x"></span>
+                <p i18n="fileimport.upload.processing">Traitement en cours</p>
+            </div>
+        </div>
+    </div>
+    <input type="file" name="filebutton" onchange="fileimport.loadLocalFile('${oLayer.layerid}')" style="visibility:hidden;" id="loadcsv-${oLayer.layerid}"/>`;
+  };
+
+  /**
+   * Private method _loadUrlFile
+   * Reads csv from URL and calls _initCsvModal with parsed data.
+   * @param {*} idLayer
+   */
+  const _loadUrlFile = function (idLayer) {
+    const url = document.getElementById("importFileByUrl").value;
+    const oLayer = mviewer.getLayers()[idLayer];
+    // read csv from URL
+    fetch(url).then((response) => {
+      if (response.ok) {
+        response.text().then((data) => {
+          // parse csv to json
+          console.log(data);
+
+          _initCsvModal(idLayer, data, oLayer, "grist.csv");
+
+          // var tmp = Papa.parse(data, { header: true });
+
+          // call _mapCSV with parsed data
+          // _mapCSV(data, mviewer.getLayers()[idLayer], mviewer.getLayers()[idLayer].layer);
+        });
+      } else {
+        var alertText = _getI18NAlertMessage(
+          "Problème avec la récupération du fichier csv",
+          "fileimport.alert.fileloading"
+        );
+        mviewer.alert(alertText + response.statusText, "alert-warning");
+      }
+    });
   };
 
   /**
@@ -222,7 +266,7 @@ const fileimport = (function () {
         };
         reader.readAsText(file);
       } else {
-        _initCsvModal(idlayer, file, oLayer);
+        fileToData(idlayer, file, oLayer);
       }
     }
   };
@@ -247,97 +291,19 @@ const fileimport = (function () {
   };
 
   /**
-   * Private method _initCsvModal
-   * Displays and inits modal for csv import, clearing and initializing values and events.
-   * Parses csv to json. Calls _geocode() or _mapCSV() depending on presence of coords in data.
-   * @param {String} idlayer
-   * @param {File} file
-   * @param {Object} oLayer
+   * Private method fileToData
+   * Utility method for _loadLocalFile to read csv file and init modal with data from it.
+   * @param {string} idlayer
+   * @param {*} file
+   * @param {object} oLayer
    */
-  var _initCsvModal = function (idlayer, file, oLayer) {
-    _resetForms();
+  const fileToData = (idlayer, file, oLayer) => {
     var reader = new FileReader();
     //Constraint : file must be encoded in UTF-8 and first line is named fields
     reader.readAsText(file, "UTF-8");
-    reader.onload = function (evt) {
-      //Show wizard modal
-      $("#geocoding-modal").modal("show");
-      $("#geocoding-modal button.geocode").attr("data-layerid", idlayer);
-      //update layer title with file name
-      $("#geocoding-modal .csv-name").val(file.name);
-      //Parse csv file to convert it as json object
-      var tmp = Papa.parse(evt.target.result, { header: true });
-      var fields = [];
-      //Get fields of loaded file
-      tmp.meta.fields.forEach(function (f) {
-        fields.push('<a href="#" class="list-group-item">' + f + "</a>");
-      });
-      //Update 3 wizard sections with field names
-      $("#geocoding-modal .csv-fields").append(fields.join(" "));
-      //Enable selection on each item
-      $("#geocoding-modal .csv-fields a").click(function () {
-        $(this).toggleClass("active");
-      });
-      //Init coordinate tab with data and events
-      _initCoordsTab(tmp, oLayer);
-      //Launch geocoding with custom parameters
-      $("#geocoding-modal")
-        .off()
-        .on("geocoding-" + idlayer + "-ready", function (e) {
-          e.preventDefault();
-          e.stopPropagation();
-          //get select fields to use for geocoding
-          var fields = [];
-          var fusefields = [];
-          //get select fields to use for geocoding
-          $("#geocoding-modal .geocoding.csv-fields a.active").each(function (i, f) {
-            fields.push(f.textContent);
-          });
-          // update global layer parameters
-          oLayer.geocodingfields = fields;
-          // get optional selected field to use as citycode (insee)
-          if ($("#geocoding-modal .insee.csv-fields a.active").length > 0) {
-            oLayer.geocodingcitycode = $("#geocoding-modal .insee.csv-fields a.active")
-              .first()
-              .text();
-          } else {
-            oLayer.geocodingcitycode = false;
-          }
-          //Enable fuse search
-          $("#geocoding-modal .search.csv-fields a.active").each(function (i, f) {
-            fusefields.push(f.textContent);
-          });
-          if (fusefields.length > 0) {
-            oLayer.fusesearchkeys = fusefields.join(",");
-            oLayer.fusesearchresult = "{{" + fusefields[0] + "}}";
-            oLayer.searchengine = "fuse";
-            // Enable tooltip as well
-            oLayer.tooltip = true;
-            oLayer.tooltipcontent = oLayer.fusesearchresult;
-            search.processSearchableLayer(oLayer);
-          }
-          //update layer title in legend panel
-          var title = $("#geocoding-modal .csv-name").val();
-          $(".mv-layer-details[data-layerid='" + idlayer + "'] .layerdisplay-title>a")
-            .first()
-            .text(title);
-          $(".mv-layer-details[data-layerid='" + idlayer + "']").data(
-            "data-layerid",
-            title
-          );
-
-          if ($("#collapseZero").hasClass("in") !== false) {
-            oLayer.xfield = $("#x-select").val();
-            oLayer.yfield = $("#y-select").val();
-            _mapCSV(evt.target.result, oLayer, oLayer.layer, $("#srs-select").val());
-          } else {
-            // geocode file
-            _geocode(evt.target.result, oLayer, oLayer.layer);
-          }
-          //hide wizard
-          $("#geocoding-modal").modal("hide");
-          return false;
-        });
+    reader.onload = (evt) => {
+      const data = evt.target.result;
+      _initCsvModal(idlayer, data, oLayer, file.name);
     };
     reader.onerror = function (evt) {
       alert(
@@ -347,6 +313,97 @@ const fileimport = (function () {
         )
       );
     };
+  };
+
+  /**
+   * Private method _initCsvModal
+   * Displays and inits modal for csv import, clearing and initializing values and events.
+   * Parses csv to json. Calls _geocode() or _mapCSV() depending on presence of coords in data.
+   * @param {String} idlayer
+   * @param {File} file
+   * @param {Object} oLayer
+   */
+  var _initCsvModal = function (idlayer, data, oLayer, name) {
+    _resetForms();
+
+    //Show wizard modal
+    $("#geocoding-modal").modal("show");
+    $("#geocoding-modal button.geocode").attr("data-layerid", idlayer);
+    //update layer title with file name
+    $("#geocoding-modal .csv-name").val(name);
+    //Parse csv file to convert it as json object
+    var tmp = Papa.parse(data, { header: true });
+    var fields = [];
+    //Get fields of loaded file
+    tmp.meta.fields.forEach(function (f) {
+      fields.push('<a href="#" class="list-group-item">' + f + "</a>");
+    });
+    //Update 3 wizard sections with field names
+    $("#geocoding-modal .csv-fields").append(fields.join(" "));
+    //Enable selection on each item
+    $("#geocoding-modal .csv-fields a").click(function () {
+      $(this).toggleClass("active");
+    });
+    //Init coordinate tab with data and events
+    _initCoordsTab(tmp, oLayer);
+    //Launch geocoding with custom parameters
+    $("#geocoding-modal")
+      .off()
+      .on("geocoding-" + idlayer + "-ready", function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        //get select fields to use for geocoding
+        var fields = [];
+        var fusefields = [];
+        //get select fields to use for geocoding
+        $("#geocoding-modal .geocoding.csv-fields a.active").each(function (i, f) {
+          fields.push(f.textContent);
+        });
+        // update global layer parameters
+        oLayer.geocodingfields = fields;
+        // get optional selected field to use as citycode (insee)
+        if ($("#geocoding-modal .insee.csv-fields a.active").length > 0) {
+          oLayer.geocodingcitycode = $("#geocoding-modal .insee.csv-fields a.active")
+            .first()
+            .text();
+        } else {
+          oLayer.geocodingcitycode = false;
+        }
+        //Enable fuse search
+        $("#geocoding-modal .search.csv-fields a.active").each(function (i, f) {
+          fusefields.push(f.textContent);
+        });
+        if (fusefields.length > 0) {
+          oLayer.fusesearchkeys = fusefields.join(",");
+          oLayer.fusesearchresult = "{{" + fusefields[0] + "}}";
+          oLayer.searchengine = "fuse";
+          // Enable tooltip as well
+          oLayer.tooltip = true;
+          oLayer.tooltipcontent = oLayer.fusesearchresult;
+          search.processSearchableLayer(oLayer);
+        }
+        //update layer title in legend panel
+        var title = $("#geocoding-modal .csv-name").val();
+        $(".mv-layer-details[data-layerid='" + idlayer + "'] .layerdisplay-title>a")
+          .first()
+          .text(title);
+        $(".mv-layer-details[data-layerid='" + idlayer + "']").data(
+          "data-layerid",
+          title
+        );
+
+        if ($("#collapseZero").hasClass("in") !== false) {
+          oLayer.xfield = $("#x-select").val();
+          oLayer.yfield = $("#y-select").val();
+          _mapCSV(data, oLayer, oLayer.layer, $("#srs-select").val());
+        } else {
+          // geocode file
+          _geocode(data, oLayer, oLayer.layer);
+        }
+        //hide wizard
+        $("#geocoding-modal").modal("hide");
+        return false;
+      });
   };
 
   /**
@@ -647,34 +704,30 @@ const fileimport = (function () {
   var _mapCSV = function (data, oLayer, l, srs) {
     var _epsg = srs ? srs : "EPSG:4326";
     var _source = l.getSource();
-    var _features = [];
     l.setStyle(getImportStyle.bind(this));
     //Parse geocoded results
     var results = Papa.parse(data, { header: true });
-    results.data.forEach(function (a) {
-      //create geometries from xfield and y field
-      if (a[oLayer.xfield] && a[oLayer.yfield]) {
-        var feature = new ol.Feature({
-          geometry: new ol.geom.Point(
-            ol.proj.transform(
-              [
-                parseFloat(a[oLayer.xfield].replace(",", ".")),
-                parseFloat(a[oLayer.yfield].replace(",", ".")),
-              ],
-              ol.proj.get(_epsg),
-              oLayer.mapProjection
-            )
-          ),
-        });
-        feature.setProperties(a);
-        _features.push(feature);
-      } else {
-        console.log("paramètres xfield et yfields manquants");
-      }
+
+    let withXY = results.data.filter((f) => f[oLayer.xfield] && f[oLayer.yfield]);
+    let features = withXY.map((f) => {
+      var feature = new ol.Feature({
+        geometry: new ol.geom.Point(
+          ol.proj.transform(
+            [
+              parseFloat(f[oLayer.xfield].replace(",", ".")),
+              parseFloat(f[oLayer.yfield].replace(",", ".")),
+            ],
+            ol.proj.get(_epsg),
+            oLayer.mapProjection
+          )
+        ),
+      });
+      feature.setProperties(f);
+      return feature;
     });
     // Add features to layer source
     // if fusesearch is enabled in config, 'change' event is fired and handled in the  _processSearchableLayer method (search.js)
-    _source.addFeatures(_features);
+    _source.addFeatures(features);
     // zoom to layer extent
     utils.zoomToFeaturesExtent(_source.getFeatures());
     $("#csv-status").attr("class", "start");
@@ -852,6 +905,7 @@ const fileimport = (function () {
       });
     },
     loadLocalFile: _loadLocalFile,
+    loadUrlFile: _loadUrlFile,
     geocodeit: _geocodeit,
     dragOverHandler: function (ev) {
       // Prevent default behavior (Prevent file from being opened)

--- a/demo/csv.xml
+++ b/demo/csv.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config>
     <application title="Mviewer CSV" mouseposition="false" logo="" help="mviewer_help.html" measuretools="true" exportpng="false" style="css/themes/wet_asphalt.css" togglealllayersfromtheme="true"/>
-    <mapoptions maxzoom="19" projection="EPSG:3857" center="695309,6222570" zoom="12" projextent="-20037508.342789244, -20037508.342789244, 20037508.342789244, 20037508.342789244" />
+    <mapoptions maxzoom="19" projection="EPSG:3857" center="345178.7959843283, 6056420.492982192" zoom="6" projextent="-20037508.342789244, -20037508.342789244, 20037508.342789244, 20037508.342789244" />
 
     <baselayers style="default"><!-- style="default"||gallery" -->
         <baselayer  type="OSM" id="positron" label="Positron" title="CartoDb" thumbgallery="img/basemap/positron.png"
@@ -19,7 +19,8 @@
     </extensions>
     <themes>
         <theme name="csv"  collapsed="false" id="csv" icon="fas fa-users">
-            <layer type="import" id="csv1" name="Fichier CSV chargé au démarrage"  visible="false"
+            <layer type="import" id="csv1" name="Fichier CSV chargé au démarrage"
+                visible="false"
                 queryable="true"
                 vectorlegend="true"
                 geocoder="search"

--- a/js/configuration.js
+++ b/js/configuration.js
@@ -986,22 +986,7 @@ var configuration = (function () {
             } // end kml
 
             if (oLayer.type === "import") {
-              l = new ol.layer.Vector({
-                source: new ol.source.Vector(),
-              });
-              if (layer.projections) {
-                oLayer.projections = layer.projections;
-              }
-              if (layer.geocodingfields) {
-                oLayer.geocodingfields = layer.geocodingfields.split(",");
-              }
-              oLayer.geocoder = layer.geocoder || false;
-              oLayer.geocoderurl = layer.geocoderurl || false;
-              //                        oLayer.xfield = layer.xfield;
-              //                        oLayer.yfield = layer.yfield;
-              //allow transformation to mapProjection before map is initialized
-              oLayer.mapProjection = conf.mapoptions.projection;
-              mviewer.processLayer(oLayer, l);
+              l = _createVectorLayer(oLayer, layer);
             } // end import
 
             if (oLayer.type === "customlayer") {
@@ -1233,6 +1218,27 @@ var configuration = (function () {
     mviewer.processLayer(oLayer, l);
   };
 
+  const _createVectorLayer = (oLayer, layer) => {
+    console.log(oLayer);
+    const conf = configuration.getConfiguration();
+    const vectorLayer = new ol.layer.Vector({
+      source: new ol.source.Vector(),
+    });
+    if (layer.projections) {
+      oLayer.projections = layer.projections;
+    }
+    if (layer.geocodingfields) {
+      oLayer.geocodingfields = layer.geocodingfields.split(",");
+    }
+    oLayer.geocoder = layer.geocoder || false;
+    oLayer.geocoderurl = layer.geocoderurl || false;
+
+    // allow transformation to mapProjection before map is initialized
+    oLayer.mapProjection = conf.mapoptions.projection;
+    mviewer.processLayer(oLayer, vectorLayer);
+    return vectorLayer;
+  };
+
   return {
     parseXML: _parseXML,
     getExtensions: _getExtensions,
@@ -1272,5 +1278,6 @@ var configuration = (function () {
     },
     getEnvData: _getEnvData,
     renderEnvPath: _renderEnvPath,
+    createVectorLayer: _createVectorLayer,
   };
 })();

--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -2410,6 +2410,12 @@ mviewer = (function () {
       }
       linkParams.mode = $("input[name=mv-display-mode]:checked").val();
 
+      if (API.file) {
+        linkParams.file = encodeURIComponent(API.file);
+        linkParams.xfield = API?.xfield;
+        linkParams.yfield = API?.yfield;
+      }
+
       //Get extra params from API. Params has to begin with c_
       let reg = /^c_(.*)/;
       for (const [key, value] of Object.entries(API)) {


### PR DESCRIPTION
> ref #1010

## Description

Cette PR permet de couvrir plusieurs cas :

1. Avoir un champ qui permet de saisir une URL de fichier à lire

2. Pouvoir ajouter dans l'URL de la carte mviewer 3 paramètres (file, xfield, yfield) pour charger un csv à la volée (nécessite que fileimport soit actif dans la config XML de la carte). La couche sera créée à la volée et n'aura pas besoin d'être définie dans le XML.

3. Pouvoir voir dans Grist un mviewer qui affiche les données du tableau (_attention : les filtres ne s'appliquent pas automatiquement et nécessitent de mettre à jour le lien du CSV lu par mviewer_)

**Todo avant suppression du statut DRAFT :** 

- [ ] Plus de tests
- [ ] Permettre la manipulation de la couche via la TOC
- [ ] MAJ documentation
- [ ] Voir si d'autres paramètres sont utiles à passer via l'URL (e.g sld, title...)
- [ ] Review
- [ ] Partage de carte - Conserver l'URL du fichier dans les paramètre URL de la carte (si le csv est importé via une URL)

**Tests possibles :** 

- https://grist.numerique.gouv.fr/o/docs/1HG28XWE7Ypy/Test-geocodage/p/2
- [Cette branche] - https://gis.jdev.fr/mviewercsv/?config=demo/csv.xml&file=https%3A%2F%2Fgrist.numerique.gouv.fr%2Fapi%2Fdocs%2F1HG28XWE7Ypy9eBJzper6N%2Fdownload%2Fcsv%3FtableId%3DMviewer


### Image cas 1

![GRIST_MVIEWER](https://github.com/user-attachments/assets/49198319-4484-4911-963c-0c39ec6d2b96)

Une variante avec un mviewer dans grist directement pour le géocodage (sans utilise l'addon geocodage de Grist) :

![GRIST_MVIEWER_2](https://github.com/user-attachments/assets/8594fb75-895f-4dfb-a6a8-b1e1108622b5)

### Image Cas 2

![GRIST_MVIEWER_3_dyn](https://github.com/user-attachments/assets/d58c0346-908b-4802-b39b-64537948847b)



