### PR TITLE
API adresse.data.gouv to IGN

### DIFF
--- a/apps/default.xml
+++ b/apps/default.xml
@@ -12,7 +12,7 @@
             attribution="GéoBretagne. Données : les contributeurs d'&lt;a href='https://www.openstreetmap.org/' target='_blank'>OpenStreetMap &lt;/a>,  &lt;a href='https://www.openstreetmap.org/copyright' target='_blank'>ODbL &lt;/a>" />
     </baselayers>     
     <proxy url=""/>
-    <!-- <olscompletion url="https://api-adresse.data.gouv.fr/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la BAN"/> -->
+    <olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/> -->
     <olscompletion url="https://data.geopf.fr/geocodage/completion" type="ign" attribution="IGN"/>
 
     <searchparameters bbox="false" localities="true" features="false" />   

--- a/apps/default.xml
+++ b/apps/default.xml
@@ -13,7 +13,7 @@
     </baselayers>     
     <proxy url=""/>
     <olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/> -->
-    <olscompletion url="https://data.geopf.fr/geocodage/completion" type="ign" attribution="IGN"/>
+    <!-- <olscompletion url="https://data.geopf.fr/geocodage/completion" attribution="IGN"/> -->
 
     <searchparameters bbox="false" localities="true" features="false" />   
 

--- a/demo/addlayers.xml
+++ b/demo/addlayers.xml
@@ -21,7 +21,7 @@
         <baselayer  type="fake" id="fake" label="Carroyage" title="Carroyage" thumbgallery="img/basemap/grid.png" visible="false"  />
     </baselayers>     
     <proxy url=""/>
-    <olscompletion url="https://api-adresse.data.gouv.fr/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la BAN"/>
+    <olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
     <searchparameters bbox="false" localities="true" features="false" />   
 
     <themes> 

--- a/demo/addons/fileimport/fileimport.js
+++ b/demo/addons/fileimport/fileimport.js
@@ -598,7 +598,7 @@ const fileimport = (function () {
         processData: false,
         url: oLayer.geocoderurl
           ? oLayer.geocoderurl
-          : "https://api-adresse.data.gouv.fr/search/csv/",
+          : "https://data.geopf.fr/geocodage/search/csv/",
         data: formData,
         contentType: false,
         success: function (data) {

--- a/demo/api.mst
+++ b/demo/api.mst
@@ -35,7 +35,7 @@
 	var url_gpu = '';
 
 	if (mviewer.clickedCoordinates) {
-		var urladdr ="https://api-adresse.data.gouv.fr/reverse/?lon="+mviewer.clickedCoordinates.x+"&lat="+mviewer.clickedCoordinates.y;
+		var urladdr ="https://data.geopf.fr/geocodage/reverse/?lon="+mviewer.clickedCoordinates.x+"&lat="+mviewer.clickedCoordinates.y;
 		url_gpu = "https://apicarto.ign.fr/api/gpu/zone-urba?geom=%7B%22type%22%3A%20%22Point%22%2C%22coordinates%22%3A%5B"+mviewer.clickedCoordinates.x+"%2C"+mviewer.clickedCoordinates.y+"%5D%7D";
 		console.log(url_gpu);
 		

--- a/demo/api.xml
+++ b/demo/api.xml
@@ -19,7 +19,7 @@
             attribution="&lt;a href='https://geoservices.ign.fr/services-web-essentiels/' target='_blank'>&lt;img src='https://geoservices.ign.fr/themes/custom/ignpro/logo.svg' width=100px>&lt;/a>" style="normal" matrixset="PM" maxzoom="22"/>
     </baselayers> 
     <authentification url="who" loginurl="?login" logouturl="../j_spring_security_logout" enabled="true"/>
-    <olscompletion url="https://api-adresse.data.gouv.fr/search/" type="ban" attribution="La recherche d'adresse est un service proposé par l'API adresse.data.gouv.fr"/>
+    <olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
     <searchparameters bbox="true" localities="true" features="false"/>
    
 

--- a/demo/cadastre.xml
+++ b/demo/cadastre.xml
@@ -11,13 +11,13 @@
 			visible="false" attribution="Map tiles by  &lt;a href='https://cartodb.com/attributions'>CartoDb &lt;/a>, under  &lt;a href='https://creativecommons.org/licenses/by/3.0/'>CC BY 3.0 &lt;/a>" />
     </baselayers>
     <urlparams fill="" stroke="rgba(232, 19, 232,0.6)" >
-        <qtype name="ban" url="https://api-adresse.data.gouv.fr/search/" />
+        <qtype name="ban" url="https://data.geopf.fr/geocodage/search" />
         <qtype name="cadastre" url="https://apicarto.ign.fr/api/cadastre/parcelle" />
         <qtype name="admin" url="https://geo.api.gouv.fr" />
         <qtype name="features" url="https://gis.jdev.fr/geoserver" />
     </urlparams>
     <proxy url=""/>    
-    <olscompletion url="http://api-adresse.data.gouv.fr/search/" type="ban" attribution="La recherche d'adresse est un service proposé par l'API adresse.data.gouv.fr"/>
+    <olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
     <themes>
         <theme name="Couches de cadastre.gouv.fr"  id="cadastre_gouv2" collapsed="false" icon="fas fa-home">             
             <layer id="cad2" name="Cadastre complet" visible="true" queryable="false" expanded="true"

--- a/demo/cog-geotiff/cog.xml
+++ b/demo/cog-geotiff/cog.xml
@@ -16,7 +16,7 @@
         <baselayer type="fake" id="fake" label="Carroyage" title="Carroyage" thumbgallery="img/basemap/grid.png" visible="false" />
     </baselayers>
     <proxy url=""/>
-    <olscompletion url="https://api-adresse.data.gouv.fr/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la BAN"/>
+    <olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
     <searchparameters bbox="false" localities="true" features="false" />
     <themes>
         <theme name="COG" collapsed="false" id="COG" icon="fas fa-users">

--- a/demo/cql.xml
+++ b/demo/cql.xml
@@ -11,7 +11,7 @@
 			url="http://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png" 
 			attribution="Données : les contributeurs d'&lt;a href='https://www.openstreetmap.org/' target='_blank'>OpenStreetMap &lt;/a>,  &lt;a href='https://www.openstreetmap.org/copyright' target='_blank'>ODbL &lt;/a>" visible="true"/>
     </baselayers>
-    <olscompletion url="https://api-adresse.data.gouv.fr/search/" type="ban" attribution="La recherche d'adresse est un service proposé par l'API adresse.data.gouv.fr"/>
+    <olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
     <searchparameters bbox="true" localities="false" features="false"/>	
 
     <themes mini="true">

--- a/demo/csv.xml
+++ b/demo/csv.xml
@@ -12,7 +12,7 @@
             attribution="© MapQuest. Données : les contributeurs d'&lt;a href='https://www.openstreetmap.org/' target='_blank'>OpenStreetMap &lt;/a>,  &lt;a href='https://www.openstreetmap.org/copyright' target='_blank'>ODbL &lt;/a>" visible="false"/>
     </baselayers>
     <proxy url=""/>
-    <olscompletion url="https://api-adresse.data.gouv.fr/search/" type="ban"/>
+    <olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
     <searchparameters bbox="false" localities="false" features="false" />
     <extensions>
         <extension type="component" id="fileimport" path="demo/addons"/>

--- a/demo/customlayer.xml
+++ b/demo/customlayer.xml
@@ -12,7 +12,7 @@
     togglealllayersfromtheme="false">
 </application>
 <mapoptions maxzoom="18" projection="EPSG:3857" center="-324758.482762259,6050184.623044413" zoom="15" />
-<olscompletion type="ban" url="https://api-adresse.data.gouv.fr/search/" attribution="" />
+<olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
 <searchparameters bbox="false" localities="true" features="false" static="false"/>
 <baselayers style="default">
     <baselayer visible="false" id="positron" thumbgallery="img/basemap/positron.png" title="CartoDb" label="Positron" type="OSM" url="https://{a-c}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png" attribution="Map tiles by  &lt;a href=&quot;https://cartodb.com/attributions&quot;&gt;CartoDb&lt;/a&gt;, under  &lt;a href=&quot;https://creativecommons.org/licenses/by/3.0/&quot;&gt;CC BY 3.0 &lt;/a&gt;"  ></baselayer>

--- a/demo/dataviz.xml
+++ b/demo/dataviz.xml
@@ -14,7 +14,7 @@
             attribution="© MapQuest. Données : les contributeurs d'&lt;a href='https://www.openstreetmap.org/' target='_blank'>OpenStreetMap &lt;/a>,  &lt;a href='https://www.openstreetmap.org/copyright' target='_blank'>ODbL &lt;/a>" visible="false"/>
     </baselayers>
     <proxy url=""/>
-    <olscompletion url="https://api-adresse.data.gouv.fr/search/" type="ban"/>
+    <olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
     <searchparameters localities="false" features="true" bbox="false"/>
 
     <themes mini="true">

--- a/demo/draw/draw.xml
+++ b/demo/draw/draw.xml
@@ -19,7 +19,7 @@
  
 	</baselayers>     
     <proxy url=""/>
-    <!-- <olscompletion url="https://api-adresse.data.gouv.fr/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la BAN"/> -->
+    <olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/> -->
     <olscompletion url="https://data.geopf.fr/geocodage/completion" type="ign" attribution="IGN"/>
 
     <searchparameters bbox="false" localities="true" features="false" />   

--- a/demo/draw/draw2.xml
+++ b/demo/draw/draw2.xml
@@ -19,7 +19,7 @@
  
 	</baselayers>     
     <proxy url=""/>
-    <!-- <olscompletion url="https://api-adresse.data.gouv.fr/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la BAN"/> -->
+    <olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/> -->
     <olscompletion url="https://data.geopf.fr/geocodage/completion" type="ign" attribution="IGN"/>
 
     <searchparameters bbox="false" localities="true" features="false" />   

--- a/demo/els2.xml
+++ b/demo/els2.xml
@@ -12,7 +12,7 @@
     togglealllayersfromtheme="false">
 </application>
 <mapoptions maxzoom="18" projection="EPSG:3857" center="-246253,6210006" zoom="8" />
-<olscompletion type="ban" url="https://api-adresse.data.gouv.fr/search/" attribution="" />
+<olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
 <searchparameters bbox="false" localities="true" features="false" static="false"/>
 <baselayers style="default">
     <baselayer visible="true" id="positron" thumbgallery="img/basemap/positron.png" title="CartoDb" label="Positron" type="OSM" url="https://{a-c}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png" attribution="Map tiles by  &lt;a href=&quot;https://cartodb.com/attributions&quot;&gt;CartoDb&lt;/a&gt;, under  &lt;a href=&quot;https://creativecommons.org/licenses/by/3.0/&quot;&gt;CC BY 3.0 &lt;/a&gt;"  ></baselayer>

--- a/demo/external.xml
+++ b/demo/external.xml
@@ -22,7 +22,7 @@
 </application>
 <mapoptions maxzoom="20" projection="EPSG:3857" center="-307903.74898791354,6141345.088741366" zoom="7" />
 <proxy url=""/>
-<olscompletion type="ban" url="https://api-adresse.data.gouv.fr/search/" attribution="Base adresse nationale (BAN)" />
+<olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
 <searchparameters bbox="false" localities="true" features="false" static="false"/>
 <baselayers style="default">
     <baselayer visible="true" id="positron" thumbgallery="img/basemap/positron.png" title="CartoDb" label="Positron" type="OSM" url="https://{a-c}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png" attribution="Map tiles by  &lt;a href=&quot;https://cartodb.com/attributions&quot;&gt;CartoDb&lt;/a&gt;, under  &lt;a href=&quot;https://creativecommons.org/licenses/by/3.0/&quot;&gt;CC BY 3.0 &lt;/a&gt;"  ></baselayer>

--- a/demo/filter/filter_download.xml
+++ b/demo/filter/filter_download.xml
@@ -16,7 +16,7 @@
         <extension type="component" id="filter" path="demo/addons"/>
 	</extensions>
 	<mapoptions maxzoom="24" projection="EPSG:2154" center="719675,7012000" zoom="8" projextent="-20037508.342789244, -20037508.342789244, 20037508.342789244, 20037508.342789244"/>
-	<olscompletion type="ban" url="https://api-adresse.data.gouv.fr/search/" attribution="" />
+	<olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
 	<searchparameters bbox="false" localities="true" features="false" static="false"/>
 	<baselayers style="gallery"><!-- style="default"||gallery" -->
 			<baselayer  type="WMS" id="osmgp1" attributioncollapsible="false" layers="faded" label="OSM - Géo2France - couleur" title="OSM" thumbgallery="apps/img/basemap/osmGP.jpg"

--- a/demo/fonds.xml
+++ b/demo/fonds.xml
@@ -33,7 +33,7 @@
         <baselayer  type="fake" id="fake" label="Carroyage" title="Carroyage" thumbgallery="img/basemap/grid.png" visible="false"  />
     </baselayers>     
     <proxy url=""/>
-    <olscompletion url="https://api-adresse.data.gouv.fr/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la BAN"/>
+    <olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
     <themes mini="true">
         <theme name="Formation"  id="formation" collapsed="true" icon="fas fa-graduation-cap">
             <layer id="lycee" name="Lycée" visible="true" tiled="false"

--- a/demo/fuse.xml
+++ b/demo/fuse.xml
@@ -9,7 +9,7 @@
             url="https://data.geopf.fr/wmts" layers="ORTHOIMAGERY.ORTHOPHOTOS" format="image/jpeg" visible="false" fromcapacity="false"
             attribution="&lt;a href='https://geoservices.ign.fr/services-geoplateforme-diffusion' target='_blank'>&lt;img src='img/basemap/geoservices.png'>&lt;/a>" style="normal" matrixset="PM" maxzoom="22"/>
     </baselayers>
-    <olscompletion url="http://api-adresse.data.gouv.fr/search/" type="ban" attribution="La recherche d'adresse est un service proposé par l'API adresse.data.gouv.fr"/>
+    <olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
     <themes>
         <theme id="lycee" name="Education" collapsed="false" icon="fas fa-book">
             <layer id="lycee"

--- a/demo/ignvectortms.xml
+++ b/demo/ignvectortms.xml
@@ -12,7 +12,7 @@
     togglealllayersfromtheme="false">
 </application>
 <mapoptions maxzoom="18" projection="EPSG:3857" center="-324758.482762259,6050184.623044413" zoom="15" />
-<olscompletion type="ban" url="https://api-adresse.data.gouv.fr/search/" attribution="" />
+<olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
 <searchparameters bbox="false" localities="true" features="false" static="false"/>
 <baselayers style="default">
     <baselayer visible="false" id="positron" thumbgallery="img/basemap/positron.png" title="CartoDb" label="Positron" type="OSM" url="https://{a-c}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png" attribution="Map tiles by  &lt;a href=&quot;https://cartodb.com/attributions&quot;&gt;CartoDb&lt;/a&gt;, under  &lt;a href=&quot;https://creativecommons.org/licenses/by/3.0/&quot;&gt;CC BY 3.0 &lt;/a&gt;"  ></baselayer>

--- a/demo/layerfilter.xml
+++ b/demo/layerfilter.xml
@@ -16,7 +16,7 @@
             attribution="© MapQuest. Données : les contributeurs d'&lt;a href='https://www.openstreetmap.org/' target='_blank'>OpenStreetMap &lt;/a>,  &lt;a href='https://www.openstreetmap.org/copyright' target='_blank'>ODbL &lt;/a>" visible="false"/>
     </baselayers>     
     <proxy url=""/>
-    <olscompletion url="https://api-adresse.data.gouv.fr/search/" type="ban"/>
+    <olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
     <searchparameters bbox="false" localities="true" features="false" />   
     <extensions>
         <extension type="component" id="layerfilter" path="demo/addons"/>

--- a/demo/mviewer_templates/config.xml
+++ b/demo/mviewer_templates/config.xml
@@ -13,7 +13,7 @@
             visible="true" attribution="Map tiles by  &lt;a href='https://cartodb.com/attributions'>CartoDb &lt;/a>, under  &lt;a href='https://creativecommons.org/licenses/by/3.0/'>CC BY 3.0 &lt;/a>" />
     </baselayers>     
     <proxy url=""/>
-    <olscompletion url="http://api-adresse.data.gouv.fr/search/" type="ban"/>
+    <olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
     <searchparameters bbox="false" localities="true" features="false" />   
 
     <themes> 

--- a/demo/print.xml
+++ b/demo/print.xml
@@ -12,7 +12,7 @@
 			attribution="Données : les contributeurs d'&lt;a href='https://www.openstreetmap.org/' target='_blank'>OpenStreetMap &lt;/a>,  &lt;a href='https://www.openstreetmap.org/copyright' target='_blank'>ODbL &lt;/a>" visible="true"/>
     </baselayers>     
     <proxy url=""/>
-    <olscompletion url="https://api-adresse.data.gouv.fr/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la BAN"/>
+    <olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
     <searchparameters bbox="false" localities="true" features="false" /> 
 
     <extensions>

--- a/demo/profile.xml
+++ b/demo/profile.xml
@@ -12,7 +12,7 @@
     togglealllayersfromtheme="false">
 </application>
 <mapoptions maxzoom="18" projection="EPSG:3857" center="-227192,6206289" zoom="12" />
-<olscompletion type="ban" url="https://api-adresse.data.gouv.fr/search/" attribution="" />
+<olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
 <searchparameters bbox="false" localities="true" features="false" static="false"/>
 <proxy url="../proxy/?url="/> 
 <baselayers style="default"> 

--- a/demo/sensor.xml
+++ b/demo/sensor.xml
@@ -18,7 +18,7 @@
             attribution="GéoBretagne. Données : les contributeurs d'&lt;a href='https://www.openstreetmap.org/' target='_blank'>OpenStreetMap &lt;/a>,  &lt;a href='https://www.openstreetmap.org/copyright' target='_blank'>ODbL &lt;/a>"/>
     </baselayers>     
     <proxy url=""/>
-    <olscompletion url="https://api-adresse.data.gouv.fr/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la BAN"/>
+    <olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
     <searchparameters bbox="false" localities="true" features="false" />   
 
     <themes> 

--- a/demo/sirene.xml
+++ b/demo/sirene.xml
@@ -11,7 +11,7 @@
 			attribution="Données : les contributeurs d'&lt;a href='https://www.openstreetmap.org/' target='_blank'>OpenStreetMap &lt;/a>,  &lt;a href='https://www.openstreetmap.org/copyright' target='_blank'>ODbL &lt;/a>" visible="true"/>
     </baselayers>
     <proxy url=""/>
-    <olscompletion url="https://api-adresse.data.gouv.fr/search/" type="ban" attribution="La recherche d'adresse est un service proposé par l'API adresse.data.gouv.fr"/>
+    <olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
     <themes mini="false">
         <theme name="Base SIRENE"   id="sirene" icon="fas fa-barcode" collapsed="false">
             <layer id="sirene_bretagne" name="Base SIRENE"  visible="true" tiled="false"

--- a/demo/superset.xml
+++ b/demo/superset.xml
@@ -19,7 +19,7 @@
             attribution="&lt;a href='https://geoservices.ign.fr/services-geoplateforme-diffusion' target='_blank'>&lt;img src='https://www.geoportail.gouv.fr/assets/images/logo-geoportail.svg'>&lt;/a>" style="normal" matrixset="PM" maxzoom="22"/>
     </baselayers> 
     <proxy url="../proxy/?url="/>
-    <olscompletion url="https://api-adresse.data.gouv.fr/search/" type="ban" attribution="La recherche d'adresse est un service proposé par l'API adresse.data.gouv.fr"/>
+    <olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
 
 
     <themes mini="false">

--- a/demo/swipe/swipe.xml
+++ b/demo/swipe/swipe.xml
@@ -12,7 +12,7 @@
     togglealllayersfromtheme="false">
 </application>
 <mapoptions maxzoom="18" projection="EPSG:3857" center="-230072,6204699" zoom="14" />
-<olscompletion type="ban" url="https://api-adresse.data.gouv.fr/search/" attribution="Base adresse nationale (BAN)" />
+<olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
 <searchparameters bbox="true" localities="true" features="false" static="false"/>
 
 <baselayers style="default">

--- a/demo/template_rightpanel.xml
+++ b/demo/template_rightpanel.xml
@@ -16,7 +16,7 @@
             attribution="© MapQuest. Données : les contributeurs d'&lt;a href='https://www.openstreetmap.org/' target='_blank'>OpenStreetMap &lt;/a>,  &lt;a href='https://www.openstreetmap.org/copyright' target='_blank'>ODbL &lt;/a>" visible="false"/>
     </baselayers>
     <proxy url=""/>
-    <olscompletion url="https://api-adresse.data.gouv.fr/search/" type="ban"/>
+    <olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
     <searchparameters bbox="false" localities="false" features="false" />
 
     <themes>

--- a/demo/theme-designfr/theme-designfr.xml
+++ b/demo/theme-designfr/theme-designfr.xml
@@ -21,7 +21,7 @@
             attribution="© MapQuest. Données : les contributeurs d'&lt;a href='https://www.openstreetmap.org/' target='_blank'>OpenStreetMap &lt;/a>,  &lt;a href='https://www.openstreetmap.org/copyright' target='_blank'>ODbL &lt;/a>" visible="false"/>
     </baselayers>     
     <proxy url=""/>
-    <olscompletion url="https://api-adresse.data.gouv.fr/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la BAN"/>
+    <olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
     <searchparameters bbox="false" localities="true" features="false" />   
 
     <extensions>

--- a/demo/time.xml
+++ b/demo/time.xml
@@ -11,7 +11,7 @@
 			attribution="Données : les contributeurs d'&lt;a href='https://www.openstreetmap.org/' target='_blank'>OpenStreetMap &lt;/a>,  &lt;a href='https://www.openstreetmap.org/copyright' target='_blank'>ODbL &lt;/a>" visible="true"/>
     </baselayers>
     <proxy url=""/>
-    <olscompletion url="https://api-adresse.data.gouv.fr/search/" type="ban" attribution="La recherche d'adresse est un service proposé par l'API adresse.data.gouv.fr"/>
+    <olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
     <themes mini="false">
         <theme name="Temporalité"   id="tempo" icon="far fa-calendar-alt">
             <layer id="buildup" name="Zones artificialisées"  visible="true" tiled="false"

--- a/demo/zoomtoarea.xml
+++ b/demo/zoomtoarea.xml
@@ -12,7 +12,7 @@
 			attribution="Données : les contributeurs d'&lt;a href='https://www.openstreetmap.org/' target='_blank'>OpenStreetMap &lt;/a>,  &lt;a href='https://www.openstreetmap.org/copyright' target='_blank'>ODbL &lt;/a>" visible="true"/>
     </baselayers>     
     <proxy url=""/>
-    <olscompletion url="https://api-adresse.data.gouv.fr/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la BAN"/>
+    <olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
     <searchparameters bbox="false" localities="true" features="false" /> 
 
     <extensions>

--- a/docs/doc_tech/config_search.rst
+++ b/docs/doc_tech/config_search.rst
@@ -20,7 +20,7 @@ Liens vers service d'autocomplétion et de géocodage d'adresses.
 
 **Attributs**
 
-* ``url``: URL du service d'autocomplétion d'adresse : BAN https://api-adresse.data.gouv.fr/search/ ou IGN  https://data.geopf.fr/geocodage/completion
+* ``url``: URL du service d'autocomplétion d'adresse : BAN https://data.geopf.fr/geocodage/search/ ou IGN  https://data.geopf.fr/geocodage/completion
 * ``type``: Optional - Type de service utilisé ign ou ban - defaut = ign
 * ``attribution``: Attribution du service de geocodage.
 
@@ -29,9 +29,7 @@ Liens vers service d'autocomplétion et de géocodage d'adresses.
 .. code-block:: xml
        :linenos:
 
-       <olscompletion url="https://api-adresse.data.gouv.fr/search/" 
-	   type="ban" 
-	   attribution="La recherche d'adresse est un service proposé par l'API adresse.data.gouv.fr"/>
+       <olscompletion url="https://data.geopf.fr/geocodage/search/" type="ban" attribution="La recherche d'adresse est un service proposé par la geoplateforme IGN"/>
 
 
 Recherche d'entités

--- a/docs/doc_tech/config_urlparams.rst
+++ b/docs/doc_tech/config_urlparams.rst
@@ -56,7 +56,7 @@ Ce paramétrage dynamique est rendu possible en ajoutant à l'URL mviewer les pa
 
 **Attributs**
 
-* ``url``: URL du service utilisé : BAN https://api-adresse.data.gouv.fr/search/ ou CADASTRE pour les parcelles cadastrales  https://apicarto.ign.fr/api/cadastre/parcelle
+* ``url``: URL du service utilisé : BAN https://data.geopf.fr/geocodage/search/ ou CADASTRE pour les parcelles cadastrales  https://apicarto.ign.fr/api/cadastre/parcelle
 * ``name``: Type de service utilisé cadastre ou ban
 * ``fill``: Couleur de l'intérieur d'un polygon (e.g code rgba)
 * ``stroke``: Couleur du contours (e.g code rgba)
@@ -67,7 +67,7 @@ Ce paramétrage dynamique est rendu possible en ajoutant à l'URL mviewer les pa
        :linenos:
 
        <urlparams fill="" stroke="rgba(232, 19, 232,0.6)" >
-              <qtype name="ban" url="https://api-adresse.data.gouv.fr/search/" />
+              <qtype name="ban" url="https://data.geopf.fr/geocodage/search/" />
               <qtype name="cadastre" url="https://apicarto.ign.fr/api/cadastre/parcelle" />
               <qtype name="admin" url="https://geo.api.gouv.fr" />
               <qtype name="features" url="https://a.map.server.fr" />


### PR DESCRIPTION
modification de l'url de l'API adresse : passage de adresse.data.gouv.fr à IGN