### PR TITLE
Add a "Street View" button to the tool list

### DIFF
--- a/demo/addons/streetview/config.json
+++ b/demo/addons/streetview/config.json
@@ -1,0 +1,14 @@
+{
+  "type": "module",
+  "js": [
+    "js/streetview.js"
+  ],
+  "css": "",
+  "html": "streetview.html",
+  "target": "toolstoolbar",
+  "options": {
+    "mviewer": {
+      "streetview": {}
+    }
+  }
+}

--- a/demo/addons/streetview/config.json
+++ b/demo/addons/streetview/config.json
@@ -1,8 +1,6 @@
 {
   "type": "module",
-  "js": [
-    "js/streetview.js"
-  ],
+  "js": ["js/streetview.js"],
   "css": "",
   "html": "streetview.html",
   "target": "toolstoolbar",

--- a/demo/addons/streetview/config.json
+++ b/demo/addons/streetview/config.json
@@ -8,7 +8,12 @@
   "target": "toolstoolbar",
   "options": {
     "mviewer": {
-      "streetview": {}
+      "streetview": {
+        "coordinates": {
+          "type": "xy"
+        },
+        "url": "http://maps.google.com/maps?q=&layer=c&cbll="
+      }
     }
   }
 }

--- a/demo/addons/streetview/js/streetview.js
+++ b/demo/addons/streetview/js/streetview.js
@@ -1,7 +1,78 @@
 var streetview = (function () {
 
+    var _map;
+
+    var _url;
+
+    var _projection;
+
+    var _streetViewBtn;
+
+    var _config;
+
+    var _typeCoordinates;
+
+    var _lastCoordinates = null;
+
     var _initStreetView = () => {
-        console.log("Street View initialized");
+        _streetViewBtn = document.getElementById("streetViewBtn");
+
+        _config = mviewer.customComponents.streetview.config.options.mviewer.streetview;
+        _typeCoordinates = _config.coordinates.type;
+        _url = _config.url;
+
+        _map = mviewer.getMap();
+        _projection = mviewer.getProjection();
+
+        _map.on("singleclick", function (evt) {
+            _handleMapClick(evt, _projection, _typeCoordinates);
+        });
+
+        _streetViewBtn.addEventListener("click", function () {
+            if (_lastCoordinates) {
+                _redirectToStreetView(_lastCoordinates);
+
+                _streetViewBtn.disabled = true;
+                setTimeout(() => {
+                    _streetViewBtn.disabled = false;
+                }, 5000);
+            } else {
+                $("#coordinates span").text("Veuillez d'abord cliquer sur la carte ✗");
+            }
+        });
+    };
+
+    var _redirectToStreetView = (coordinates) => {
+        let parts = coordinates.split(",").map((part) => part.trim());
+
+        let url = `${_url}${parts[1]},${parts[0]}`;
+
+        window.open(url, "_blank");
+    };
+
+    var _formatCoordinatesText = (coordinates, type) => {
+        const formatCoordinates =
+            type === "dms"
+            ? ol.coordinate.toStringHDMS
+            : ol.coordinate.toStringXY;
+        const coordinatePrecision = type === "dms" ? 0 : 5; // 5 decimal
+
+        let hdms = formatCoordinates(coordinates, coordinatePrecision);
+            hdms =
+            type === "xy" ? hdms : hdms.replace(/ /g, "").replace("N", "N - ");
+
+        return hdms;
+    };
+
+    var _handleMapClick = (evt, projection, typeCoordinates) => {
+        let _coordinates = ol.proj.transform(evt.coordinate, projection.getCode(), "EPSG:4326");
+        let formattedCoordinates = _formatCoordinatesText(_coordinates, typeCoordinates);
+
+        _lastCoordinates = formattedCoordinates;
+
+        console.log(formattedCoordinates);
+
+        $("#coordinates span").text("Coordonnées sauvegardées ✓");
     };
 
     return {

--- a/demo/addons/streetview/js/streetview.js
+++ b/demo/addons/streetview/js/streetview.js
@@ -1,0 +1,12 @@
+var streetview = (function () {
+
+    var _initStreetView = () => {
+        console.log("Street View initialized");
+    };
+
+    return {
+        init: _initStreetView,
+    };
+})();
+
+new CustomComponent("streetview", streetview.init);

--- a/demo/addons/streetview/js/streetview.js
+++ b/demo/addons/streetview/js/streetview.js
@@ -4,114 +4,113 @@
  * This module provides a custom component for mviewer that allows users to open Google Street View
  * at a clicked location on the map. It handles the map click event, formats the coordinates,
  * and redirects the user to the Google Street View URL with the selected coordinates.
- * 
+ *
  */
 
 var streetview = (function () {
+  var _map;
 
-    var _map;
+  var _url;
 
-    var _url;
+  var _projection;
 
-    var _projection;
+  var _streetViewBtn;
 
-    var _streetViewBtn;
+  var _config;
 
-    var _config;
+  var _typeCoordinates;
 
-    var _typeCoordinates;
+  var _lastCoordinates = null;
 
-    var _lastCoordinates = null;
+  /**
+   * Initialize the street view component
+   */
+  var _initStreetView = () => {
+    _streetViewBtn = document.getElementById("streetViewBtn");
 
-    /**
-     * Initialize the street view component
-     */
-    var _initStreetView = () => {
-        _streetViewBtn = document.getElementById("streetViewBtn");
+    _config = mviewer.customComponents.streetview.config.options.mviewer.streetview;
+    _typeCoordinates = _config.coordinates.type;
+    _url = _config.url;
 
-        _config = mviewer.customComponents.streetview.config.options.mviewer.streetview;
-        _typeCoordinates = _config.coordinates.type;
-        _url = _config.url;
+    _map = mviewer.getMap();
+    _projection = _map.getView().getProjection();
 
-        _map = mviewer.getMap();
-        _projection = _map.getView().getProjection();
+    _map.on("singleclick", function (evt) {
+      _handleMapClick(evt, _projection, _typeCoordinates);
+    });
 
-        _map.on("singleclick", function (evt) {
-            _handleMapClick(evt, _projection, _typeCoordinates);
-        });
+    _streetViewBtn.addEventListener("click", function () {
+      if (_lastCoordinates) {
+        _redirectToStreetView(_lastCoordinates);
 
-        _streetViewBtn.addEventListener("click", function () {
-            if (_lastCoordinates) {
-                _redirectToStreetView(_lastCoordinates);
-
-                _streetViewBtn.disabled = true;
-                // Disable the button for 5 seconds to prevent multiple clicks
-                setTimeout(() => {
-                    _streetViewBtn.disabled = false;
-                }, 5000);
-            } else {
-                $("#coordinates span").text("Cliquez d’abord sur la carte ✗");
-            }
-        });
-    };
-
-    /**
-     * Redirect to Google Street View with the coordinates
-     * @param {string} coordinates - The coordinates to redirect to
-     * 
-     */
-    var _redirectToStreetView = (coordinates) => {
-        let parts = coordinates.split(",").map((part) => part.trim());
-
-        let url = `${_url}${parts[1]},${parts[0]}`;
-
-        window.open(url, "_blank");
-    };
-
-    /**
-     * Format the coordinates to a string
-     * @param {Array} coordinates - The coordinates to format
-     * @param {string} type - The type of coordinates to format
-     * @returns {string} - The formatted coordinates
-     * 
-     */
-    var _formatCoordinatesText = (coordinates, type) => {
-        const formatCoordinates =
-            type === "xy"
-            ? ol.coordinate.toStringXY
-            : null;
-        const coordinatePrecision = type === "xy" ? 5 : 0; // 5 decimal
-
-        let hxy = formatCoordinates(coordinates, coordinatePrecision);
-            hxy =
-            type === "xy" ? hxy : null;
-
-        return hxy;
-    };
-
-    /**
-     * Handle the map click event
-     * @param {ol.MapBrowserEvent} evt - The map click event
-     * @param {ol.proj.Projection} projection - The map projection
-     * @param {string} typeCoordinates - The type of coordinates
-     */
-    var _handleMapClick = (evt, projection, typeCoordinates) => {
-        let _coordinates = ol.proj.transform(evt.coordinate, projection.getCode(), "EPSG:4326");
-        let formattedCoordinates = _formatCoordinatesText(_coordinates, typeCoordinates);
-
-        _lastCoordinates = formattedCoordinates;
-
-        $("#coordinates span").text("Coordonnées sauvegardées ✓");
-
-        // Clear the coordinates text after 3 seconds
+        _streetViewBtn.disabled = true;
+        // Disable the button for 5 seconds to prevent multiple clicks
         setTimeout(() => {
-            $("#coordinates span").text(" ");
-        }, 3000);
-    };
+          _streetViewBtn.disabled = false;
+        }, 5000);
+      } else {
+        $("#coordinates span").text("Cliquez d’abord sur la carte ✗");
+      }
+    });
+  };
 
-    return {
-        init: _initStreetView,
-    };
+  /**
+   * Redirect to Google Street View with the coordinates
+   * @param {string} coordinates - The coordinates to redirect to
+   *
+   */
+  var _redirectToStreetView = (coordinates) => {
+    let parts = coordinates.split(",").map((part) => part.trim());
+
+    let url = `${_url}${parts[1]},${parts[0]}`;
+
+    window.open(url, "_blank");
+  };
+
+  /**
+   * Format the coordinates to a string
+   * @param {Array} coordinates - The coordinates to format
+   * @param {string} type - The type of coordinates to format
+   * @returns {string} - The formatted coordinates
+   *
+   */
+  var _formatCoordinatesText = (coordinates, type) => {
+    const formatCoordinates = type === "xy" ? ol.coordinate.toStringXY : null;
+    const coordinatePrecision = type === "xy" ? 5 : 0; // 5 decimal
+
+    let hxy = formatCoordinates(coordinates, coordinatePrecision);
+    hxy = type === "xy" ? hxy : null;
+
+    return hxy;
+  };
+
+  /**
+   * Handle the map click event
+   * @param {ol.MapBrowserEvent} evt - The map click event
+   * @param {ol.proj.Projection} projection - The map projection
+   * @param {string} typeCoordinates - The type of coordinates
+   */
+  var _handleMapClick = (evt, projection, typeCoordinates) => {
+    let _coordinates = ol.proj.transform(
+      evt.coordinate,
+      projection.getCode(),
+      "EPSG:4326"
+    );
+    let formattedCoordinates = _formatCoordinatesText(_coordinates, typeCoordinates);
+
+    _lastCoordinates = formattedCoordinates;
+
+    $("#coordinates span").text("Coordonnées sauvegardées ✓");
+
+    // Clear the coordinates text after 3 seconds
+    setTimeout(() => {
+      $("#coordinates span").text(" ");
+    }, 3000);
+  };
+
+  return {
+    init: _initStreetView,
+  };
 })();
 
 new CustomComponent("streetview", streetview.init);

--- a/demo/addons/streetview/js/streetview.js
+++ b/demo/addons/streetview/js/streetview.js
@@ -1,3 +1,12 @@
+/**
+ * @module streetview
+ * @description
+ * This module provides a custom component for mviewer that allows users to open Google Street View
+ * at a clicked location on the map. It handles the map click event, formats the coordinates,
+ * and redirects the user to the Google Street View URL with the selected coordinates.
+ * 
+ */
+
 var streetview = (function () {
 
     var _map;
@@ -14,6 +23,9 @@ var streetview = (function () {
 
     var _lastCoordinates = null;
 
+    /**
+     * Initialize the street view component
+     */
     var _initStreetView = () => {
         _streetViewBtn = document.getElementById("streetViewBtn");
 
@@ -22,7 +34,7 @@ var streetview = (function () {
         _url = _config.url;
 
         _map = mviewer.getMap();
-        _projection = mviewer.getProjection();
+        _projection = _map.getView().getProjection();
 
         _map.on("singleclick", function (evt) {
             _handleMapClick(evt, _projection, _typeCoordinates);
@@ -33,15 +45,21 @@ var streetview = (function () {
                 _redirectToStreetView(_lastCoordinates);
 
                 _streetViewBtn.disabled = true;
+                // Disable the button for 5 seconds to prevent multiple clicks
                 setTimeout(() => {
                     _streetViewBtn.disabled = false;
                 }, 5000);
             } else {
-                $("#coordinates span").text("Veuillez d'abord cliquer sur la carte ✗");
+                $("#coordinates span").text("Cliquez d’abord sur la carte ✗");
             }
         });
     };
 
+    /**
+     * Redirect to Google Street View with the coordinates
+     * @param {string} coordinates - The coordinates to redirect to
+     * 
+     */
     var _redirectToStreetView = (coordinates) => {
         let parts = coordinates.split(",").map((part) => part.trim());
 
@@ -50,29 +68,45 @@ var streetview = (function () {
         window.open(url, "_blank");
     };
 
+    /**
+     * Format the coordinates to a string
+     * @param {Array} coordinates - The coordinates to format
+     * @param {string} type - The type of coordinates to format
+     * @returns {string} - The formatted coordinates
+     * 
+     */
     var _formatCoordinatesText = (coordinates, type) => {
         const formatCoordinates =
-            type === "dms"
-            ? ol.coordinate.toStringHDMS
-            : ol.coordinate.toStringXY;
-        const coordinatePrecision = type === "dms" ? 0 : 5; // 5 decimal
+            type === "xy"
+            ? ol.coordinate.toStringXY
+            : null;
+        const coordinatePrecision = type === "xy" ? 5 : 0; // 5 decimal
 
-        let hdms = formatCoordinates(coordinates, coordinatePrecision);
-            hdms =
-            type === "xy" ? hdms : hdms.replace(/ /g, "").replace("N", "N - ");
+        let hxy = formatCoordinates(coordinates, coordinatePrecision);
+            hxy =
+            type === "xy" ? hxy : null;
 
-        return hdms;
+        return hxy;
     };
 
+    /**
+     * Handle the map click event
+     * @param {ol.MapBrowserEvent} evt - The map click event
+     * @param {ol.proj.Projection} projection - The map projection
+     * @param {string} typeCoordinates - The type of coordinates
+     */
     var _handleMapClick = (evt, projection, typeCoordinates) => {
         let _coordinates = ol.proj.transform(evt.coordinate, projection.getCode(), "EPSG:4326");
         let formattedCoordinates = _formatCoordinatesText(_coordinates, typeCoordinates);
 
         _lastCoordinates = formattedCoordinates;
 
-        console.log(formattedCoordinates);
-
         $("#coordinates span").text("Coordonnées sauvegardées ✓");
+
+        // Clear the coordinates text after 3 seconds
+        setTimeout(() => {
+            $("#coordinates span").text(" ");
+        }, 3000);
     };
 
     return {

--- a/demo/addons/streetview/streetview.html
+++ b/demo/addons/streetview/streetview.html
@@ -1,3 +1,3 @@
-<button id="streetViewBtn" title href="#" type="button" class="mv-modetools btn btn-default btn-raised" data-original-title="StreetView" data-toggle="tooltip">
+<button id="streetViewBtn" title href="#" type="button" class="mv-modetools btn btn-default btn-raised" data-original-title="Street View" data-toggle="tooltip">
     <span class="fas fa-street-view"></span>
 </button>

--- a/demo/addons/streetview/streetview.html
+++ b/demo/addons/streetview/streetview.html
@@ -1,0 +1,1 @@
+<div>streetview button</div>

--- a/demo/addons/streetview/streetview.html
+++ b/demo/addons/streetview/streetview.html
@@ -1,1 +1,3 @@
-<div>streetview button</div>
+<button id="streetViewBtn" title href="#" type="button" class="mv-modetools btn btn-default btn-raised" data-original-title="StreetView" data-toggle="tooltip">
+    <span class="fas fa-street-view"></span>
+</button>

--- a/demo/streetview.xml
+++ b/demo/streetview.xml
@@ -1,0 +1,47 @@
+<config>
+    <!-- css/themes/wet_asphalt.css -->
+    <application id="streetview" 
+        title="Street View"
+        style="css/themes/blue.css" 
+        logo=""
+        exportpng="false" 
+        measuretools="false" 
+        mapprint="false"
+        addlayerstools="false"/>
+
+    <mapoptions maxzoom="20" projection="EPSG:3857" center="-220750.13768758904,6144925.57790189" zoom="8"/>
+
+    <baselayers style="default">
+        <baselayer  type="WMTS" id="ortho" label="Photo aérienne IGN" title="GéoPortail" maxscale="1000" thumbgallery="img/basemap/ortho.jpg"
+            url="https://data.geopf.fr/wmts" layers="ORTHOIMAGERY.ORTHOPHOTOS" format="image/jpeg" visible="false" fromcapacity="false"
+            attribution="&lt;a href='https://geoservices.ign.fr/services-geoplateforme-diffusion' target='_blank'>&lt;img src='img/basemap/geoservices.png'>&lt;/a>" style="normal" matrixset="PM" maxzoom="22"/>
+        <baselayer  type="OSM" id="osm1" attributioncollapsible="false" label="OpenStreetMap" title="OpenSTreetMap" thumbgallery="img/basemap/osm.png" 
+			url="http://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png" 
+			attribution="Données : les contributeurs d'&lt;a href='https://www.openstreetmap.org/' target='_blank'>OpenStreetMap &lt;/a>,  &lt;a href='https://www.openstreetmap.org/copyright' target='_blank'>ODbL &lt;/a>" visible="true"/>
+    </baselayers>
+
+    <extensions>
+        <extension type="component" id="streetview" path="demo/addons"/>
+    </extensions>
+
+    <themes>
+        <theme name="Découpages territoriaux"  collapsed="true" id="territoire" icon="fas fa-globe">
+			<layer id="commune" name="Commune" visible="false" queryable="false" 
+                fields="nom_geo" aliases="Nom" 
+                type="customlayer" style="" opacity="1" legendurl="https://kartenn.region-bretagne.fr/kartoviz/apps/region/territoire/img/commune.png" 
+                url="https://kartenn.region-bretagne.fr/kartoviz/apps/region/territoire/customlayers/commune.js" 
+                tooltip="true" tooltipenabled="true"
+                attribution="Source: GéoBretagne" 
+                metadata="https://geobretagne.fr/geonetwork/srv/eng/catalog.search?node=srv#/metadata/b08e6cb1-236c-49b7-88f9-42b500d274d5" 
+                metadata-csw="https://geobretagne.fr/geonetwork/srv/eng/csw?SERVICE=CSW&amp;VERSION=2.0.2&amp;REQUEST=GetRecordById&amp;elementSetName=full&amp;ID=b08e6cb1-236c-49b7-88f9-42b500d274d5"/>	    
+            <layer id="epci" name="Intercommunalité" visible="true" queryable="false" 
+                fields="nom_geo" aliases="Nom" toplayer="true"
+                type="customlayer" style="" opacity="1" legendurl="https://kartenn.region-bretagne.fr/kartoviz/apps/region/territoire/img/epci.png" 
+                url="https://kartenn.region-bretagne.fr/kartoviz/apps/region/territoire/customlayers/epci.js" 
+                tooltip="true" tooltipenabled="true"
+                attribution="Source: GéoBretagne" 
+                metadata="https://geobretagne.fr/geonetwork/srv/eng/catalog.search?node=srv#/metadata/2298d744-49cb-4fcb-9487-26f916fecdff" 
+                metadata-csw="https://geobretagne.fr/geonetwork/srv/eng/csw?SERVICE=CSW&amp;VERSION=2.0.2&amp;REQUEST=GetRecordById&amp;elementSetName=full&amp;ID=2298d744-49cb-4fcb-9487-26f916fecdff"/>           
+        </theme>
+    </themes>
+</config>


### PR DESCRIPTION
**This pull request addresses issue #1024, which aims to improve user experience by providing direct access to Google Street View from the map interface.**

This PR adds a new `addon` component for mviewer that captures map click events, saves the last clicked coordinates, and enables users to open Google Street View centered on that location by redirecting to the corresponding URL.