### PR TITLE
fix #1131 - clear search on each keydown timeout

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -244,6 +244,7 @@ var search = (function () {
       // TIMEOUT will avoid one request by keyup
       clearTimeout(timeoutId);
       timeoutId = setTimeout(() => {
+        _clearSearchResults();
         // Avoid double trigger
         if (isPasting && e.key.toLowerCase() === "v") {
           isPasting = false;


### PR DESCRIPTION
> ref #1131

Petit correctif pour vider la recherche à chaque saisie, ou quand la recherche est vidée.

Cas que ce correctif couvrent : 

1. saisir "Rennes" dans le champ de saisie de recherche 
2. Voir que la liste affiche des résultats
3. Vider le texte saisie
4. Voir que la liste affiche toujours les résultats précédents --> KO !
5. Saisir "Brest"
6. Voir que la liste affiche la saisie précédente de "Rennes" et les nouveaux résultats pour Brest