### PR TITLE
chore: customize default.conf for increase large_client_header_buffers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,6 @@ FROM nginxinc/nginx-unprivileged:alpine
 
 VOLUME ["/usr/share/nginx/html/apps"]
 
+COPY docker/nginx/default.conf /etc/nginx/conf.d/default.conf
+
 COPY . /usr/share/nginx/html/

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,0 +1,16 @@
+server {
+    listen       8080;
+    server_name  localhost;
+
+    large_client_header_buffers 4 16k;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
Some users (for example, Geo2France) are passing a very long URL to Mviewer. About 4,800 characters long.

With the default NGINX parameters, this URL doesn't work due to the too big size and return this error: `414 Request URI Too Long`.

This pull request customize the default.conf file of NGINX in order to accept larger URLs.