### PR TITLE
Mise à jour de la recherche ELS et création d'un paramètre pour la gestion du niveau de zoom FUSE/ELS

### DIFF
--- a/demo/els.xml
+++ b/demo/els.xml
@@ -1,7 +1,7 @@
 <config>
     <application title="Démo ElasticSearch" logo="" help="demo/demo_els_help.html" showhelp="true" style="css/themes/nephritis.css" exportpng="false" measuretools="false" />
     <mapoptions maxzoom="20" projection="EPSG:3857" center="-307903.74898791354,6141345.088741366" zoom="7" />
-    <searchparameters localities="false" features="true" bbox="true"/>
+    <searchparameters localities="false" features="true" bbox="true" querymaponclick="true" closeafterclick="true" searchmaxzoomlevel="12"/>
 	<elasticsearchs>
 		<elasticsearch url="https://ows.region-bretagne.fr/els/lycee/_search" geometryfield="location" linkid="search_id" querymode="match" 
 			version="7.17" geometryformat="WKT" mouseoverfields="title" displayfields="title" layer="lycee"/>

--- a/docs/doc_tech/config_search.rst
+++ b/docs/doc_tech/config_search.rst
@@ -65,7 +65,8 @@ Options liées à la recherche d'adresse *(olscompletion)* et/ou à la recherche
               querymaponclick=""
               closeafterclick=""
               animate=""
-              duration=""/>
+              duration=""
+              searchmaxzoomlevel=""/>
 
 **Attributs**
 
@@ -82,6 +83,7 @@ Options liées à la recherche d'adresse *(olscompletion)* et/ou à la recherche
 * ``imgurl`` *(optionnel)* : Url de l'image PNG / JPEG à afficher à l'emplacement du résultat sélectionné en guise de pointeur.
 * ``imgwidth`` *(optionnel)* : Taille de l'image (voir paramètre imgurl) du pointeur représentant le résultat sélectionné.
 * ``svgcolor`` *(optionnel)* : Couleur du pointeur représentant la localisation du résultat sélectionné.
+* ``searchmaxzoomlevel`` *(optionnel)* : définit le niveau de zoom maximal appliqué lors d'une recherche ELS ou fuse (valeur par défaut = 15) Pour une géométrie de type polygone ou multi-polygone, le zoom est calculé selon l'étendue.
 
 .. figure:: ../_images/dev/config_search/option-animate.gif
             :alt: activation de l'option animate

--- a/js/search.js
+++ b/js/search.js
@@ -326,8 +326,8 @@ var search = (function () {
                   ${_searchparams.querymaponclick}
               );
               mviewer.showLocation('${_proj4326}', ${coords[0]}, ${coords[1]}, ${
-        _searchparams.marker
-      });">
+                _searchparams.marker
+              });">
               ${props?.label || res[i].fulltext}
           </a>`;
     }
@@ -458,12 +458,12 @@ var search = (function () {
             <a class="fuse list-group-item" title="${result_label}" 
                 href="#" onclick="
                   mviewer.animateToFeature(${JSON.stringify([xyz.lon, xyz.lat])}, ${
-            xyz.zoom
-          }, ${JSON.stringify(extentCenter)}, ${_searchparams.querymaponclick}); 
+                    xyz.zoom
+                  }, ${JSON.stringify(extentCenter)}, ${_searchparams.querymaponclick}); 
                   mviewer.showLocation('${_proj4326}', ${xyz.lon}, ${xyz.lat}, false);" 
                 onmouseover="mviewer.flash('${_proj4326}', ${xyz.lon}, ${
-            xyz.lat
-          }, false);">
+                  xyz.lat
+                }, false);">
               ${result_label}
             </a>`;
         });
@@ -963,11 +963,10 @@ var search = (function () {
                   feature.setId("feature." + indexId + "." + j);
                   _sourceEls.addFeature(feature);
 
-                  action_click +=
-                    `mviewer.animateToFeature(${JSON.stringify([xyz.lon, xyz.lat])}, ${xyz.zoom}, ${JSON.stringify(extentCenter)}, false); 
+                  action_click += `mviewer.animateToFeature(${JSON.stringify([xyz.lon, xyz.lat])}, ${xyz.zoom}, ${JSON.stringify(extentCenter)}, false); 
                     mviewer.showLocation('${_proj4326}', ${xyz.lon}, ${xyz.lat}, false);`;
-                  
-                    //If index has the same name than a mviewer layer make the query on layer
+
+                  //If index has the same name than a mviewer layer make the query on layer
                   if (_overLayers[indexId] && _searchparams.querymaponclick) {
                     _overLayers[indexId].searchid = _elasticSearchLinkid.get(indexId);
                     action_click +=
@@ -1231,7 +1230,9 @@ var search = (function () {
       _searchparams.static = sparams.static === "true";
       _searchparams.querymaponclick = sparams.querymaponclick === "true";
       _searchparams.closeafterclick = sparams.closeafterclick === "true";
-      _searchparams.searchmaxzoomlevel = sparams.searchmaxzoomlevel ? sparams.searchmaxzoomlevel : 15;
+      _searchparams.searchmaxzoomlevel = sparams.searchmaxzoomlevel
+        ? sparams.searchmaxzoomlevel
+        : 15;
     }
 
     if (_searchparams.localities === false && _searchparams.features === false) {

--- a/js/search.js
+++ b/js/search.js
@@ -326,8 +326,8 @@ var search = (function () {
                   ${_searchparams.querymaponclick}
               );
               mviewer.showLocation('${_proj4326}', ${coords[0]}, ${coords[1]}, ${
-                _searchparams.marker
-              });">
+        _searchparams.marker
+      });">
               ${props?.label || res[i].fulltext}
           </a>`;
     }
@@ -458,12 +458,12 @@ var search = (function () {
             <a class="fuse list-group-item" title="${result_label}" 
                 href="#" onclick="
                   mviewer.animateToFeature(${JSON.stringify([xyz.lon, xyz.lat])}, ${
-                    xyz.zoom
-                  }, ${JSON.stringify(extentCenter)}, ${_searchparams.querymaponclick}); 
+            xyz.zoom
+          }, ${JSON.stringify(extentCenter)}, ${_searchparams.querymaponclick}); 
                   mviewer.showLocation('${_proj4326}', ${xyz.lon}, ${xyz.lat}, false);" 
                 onmouseover="mviewer.flash('${_proj4326}', ${xyz.lon}, ${
-                  xyz.lat
-                }, false);">
+            xyz.lat
+          }, false);">
               ${result_label}
             </a>`;
         });
@@ -963,7 +963,10 @@ var search = (function () {
                   feature.setId("feature." + indexId + "." + j);
                   _sourceEls.addFeature(feature);
 
-                  action_click += `mviewer.animateToFeature(${JSON.stringify([xyz.lon, xyz.lat])}, ${xyz.zoom}, ${JSON.stringify(extentCenter)}, false); 
+                  action_click += `mviewer.animateToFeature(${JSON.stringify([
+                    xyz.lon,
+                    xyz.lat,
+                  ])}, ${xyz.zoom}, ${JSON.stringify(extentCenter)}, false); 
                     mviewer.showLocation('${_proj4326}', ${xyz.lon}, ${xyz.lat}, false);`;
 
                   //If index has the same name than a mviewer layer make the query on layer

--- a/js/search.js
+++ b/js/search.js
@@ -422,7 +422,7 @@ var search = (function () {
       var layerid = searchableLayers[i].get("mviewerid");
 
       var results = _fuseSearchData[layerid].search(val);
-      var zoom = 15;
+      var zoom = _searchparams.searchmaxzoomlevel;
       var max_results = 5;
       var str = "";
       if (results.length > 0) {
@@ -922,6 +922,7 @@ var search = (function () {
                 let titleDisplayKey = "id";
                 var nb = data.hits.hits.length;
                 let formatELS = new ol.format.GeoJSON();
+                let zoom = _searchparams.searchmaxzoomlevel;
 
                 if (nb > 0) {
                   indexId = data.hits.hits[0]._index;
@@ -940,6 +941,8 @@ var search = (function () {
                   let geom = formatELS.readGeometry(currentFeature._source.location);
 
                   let xyz = mviewer.getLonLatZfromGeometry(geom, _proj4326, zoom);
+
+                  let extentCenter = _getCenterWithExtent(geom, _proj4326);
 
                   var title = "";
                   title += $.map(currentFeature._source, function (value, key) {
@@ -961,10 +964,11 @@ var search = (function () {
                   _sourceEls.addFeature(feature);
 
                   action_click +=
-                    "mviewer.zoomToFeature('feature." + indexId + "." + j + "', 16);";
-
-                  //If index has the same name than a mviewer layer make the query on layer
-                  if (_overLayers[indexId]) {
+                    `mviewer.animateToFeature(${JSON.stringify([xyz.lon, xyz.lat])}, ${xyz.zoom}, ${JSON.stringify(extentCenter)}, false); 
+                    mviewer.showLocation('${_proj4326}', ${xyz.lon}, ${xyz.lat}, false);`;
+                  
+                    //If index has the same name than a mviewer layer make the query on layer
+                  if (_overLayers[indexId] && _searchparams.querymaponclick) {
                     _overLayers[indexId].searchid = _elasticSearchLinkid.get(indexId);
                     action_click +=
                       "mviewer.tools.info.queryLayer(" +
@@ -1227,6 +1231,7 @@ var search = (function () {
       _searchparams.static = sparams.static === "true";
       _searchparams.querymaponclick = sparams.querymaponclick === "true";
       _searchparams.closeafterclick = sparams.closeafterclick === "true";
+      _searchparams.searchmaxzoomlevel = sparams.searchmaxzoomlevel ? sparams.searchmaxzoomlevel : 15;
     }
 
     if (_searchparams.localities === false && _searchparams.features === false) {


### PR DESCRIPTION
Cette PR contient les modifications suivantes : 
- Utilisation de la méthode `mviewer.animateToFeature` pour la recherche ELS 
- Prise en compte du paramètre `querymaponclick` pour la recherche ELS (interrogation de l'entité sélectionnée seulement si `true`)
- Création d'un nouveau paramètre `searchmaxzoomlevel` dans `searchparameters` pour gérer le niveau de zoom d'une recherche ELS ou FUSE. La valeur par défaut est 15 si non renseigné #447
- Mise à jour de la documentation avec le nouveau paramètre 
- Mise à jour de la demo `els.xml` avec un `searchmaxzoomlevel="12"`