### PR TITLE
Gestion de l'extent (initialisation + bouton)

### DIFF
--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -119,8 +119,12 @@ mviewer = (function () {
     if (API.x && API.y && API.z) {
       center = [parseFloat(API.x), parseFloat(API.y)];
       var zoom = parseInt(API.z);
-      _map.getView().setCenter(center);
-      _map.getView().setZoom(zoom);
+      if (_extent === null) {
+        _map.getView().setCenter(center);
+        _map.getView().setZoom(zoom);
+      } else {
+        _setExtent();
+      }
       // Flag a queryMap call if requested via URL (e.g. ?query=true)
       queryRequested = ["true", "1", "yes", "on"].includes(
         (API.query || "").toString().toLowerCase()
@@ -254,6 +258,21 @@ mviewer = (function () {
    */
 
   var _center = null;
+
+  /**
+   * Property: _extent
+   *
+   */
+
+  var _extent = null;
+
+  /**
+   * Property: _zoom
+   *
+   */
+
+  var _zoom = null;
+
   /**
    * Property: _rotation
    *
@@ -363,6 +382,44 @@ mviewer = (function () {
     _proxy = configuration.getProxy();
   };
 
+  var _setExtent = function () {
+    function getPadding(isModeU, isModeS, isMobile, isToggled) {
+      const pbMobile = parseFloat(
+        getComputedStyle(document.documentElement).getPropertyValue(
+          "--mv-navbar-mobile-h"
+        )
+      );
+      const ptSearchtool = document.getElementById("searchtool").clientHeight;
+      if (isModeU) {
+        return [ptSearchtool + 10, 0, 0, 0];
+      }
+      if (isMobile) {
+        return [ptSearchtool, 0, pbMobile, 0];
+      }
+      if (isModeS) {
+        return [ptSearchtool, 0, pbMobile, 0];
+      }
+      if (isToggled) {
+        return [0, 50, 0, 0];
+      }
+      return [0, 250, 0, 0];
+    }
+
+    if (_extent !== null) {
+      const isMobile = window.innerWidth < 992;
+      const isModeU = API.mode === "u";
+      const isModeS = API.mode === "s";
+      const isToggled = $(".menu-toggle").hasClass("closed");
+
+      const padding = getPadding(isModeU, isModeS, isMobile, isToggled);
+
+      _map.getView().fit(_extent, {
+        size: _map.getSize(),
+        padding: padding,
+      });
+    }
+  };
+
   var _initMap = function (mapoptions) {
     _zoom = parseInt(mapoptions.zoom) || 8;
     if (mapoptions.rotation === "true") {
@@ -386,6 +443,16 @@ mviewer = (function () {
           }),
         });
     }
+    _extent = mapoptions.extent
+      ? ol.proj.transformExtent(
+          mapoptions.extent.split(",").map(function (item) {
+            return parseFloat(item);
+          }),
+          "EPSG:3857",
+          mapoptions.projection
+        )
+      : null;
+
     utils.initWMTSMatrixsets(_projection);
     var overlays = [];
     // init marker to create overlay on great marker
@@ -443,22 +510,6 @@ mviewer = (function () {
           : undefined,
       }),
     });
-
-    var extent = mapoptions.extent
-      ? ol.proj.transformExtent(
-          mapoptions.extent.split(",").map(function (item) {
-            return parseFloat(item);
-          }),
-          "EPSG:3857",
-          mapoptions.projection
-        )
-      : null;
-
-    if (extent !== null) {
-      _map.getView().fit(extent, {
-        size: _map.getSize(),
-      });
-    }
 
     const mapReadyEvent = new CustomEvent("map-ready", {
       detail: {
@@ -2437,8 +2488,12 @@ mviewer = (function () {
      */
 
     zoomToInitialExtent: function () {
-      _map.getView().setCenter(_center);
-      _map.getView().setZoom(_zoom);
+      if (_extent == null) {
+        _map.getView().setCenter(_center);
+        _map.getView().setZoom(_zoom);
+      } else {
+        _setExtent();
+      }
     },
 
     /**
@@ -2917,6 +2972,7 @@ mviewer = (function () {
       _initGeolocation();
       _initTools();
       _initShare();
+      _setExtent();
     },
 
     customLayers: {},


### PR DESCRIPTION
Ces modifications s'appliquent dans le cas où une extent a été indiquée dans un fichier de configuration d'une carte. Cela permet d'avoir à l'initialisation de la carte l'extent centrée, que ce soit avec ou sans le gestionnaire de couche ouvert, que ce soit en desktop, mobile, en mode simplifiée ou ultra simplifié.

Également, j'ai ajouté cette fonction au bouton "Revenir à l'étendue géographique de départ", donc en ouvrant ou fermant le panneau, le centrage sera correct.

Vous pouvez utiliser cette extent pour tester avec le fichier default.xml dans apps/ : `extent="-583805, 5936188, -101575, 6309438"`.

TODO:
- J'ai un problème où j'ai quelques pixels qui s'ajoutent après l'initialisation de la carte en mobile ou simplifié, ultra simplifié, où appuyer sur le bouton après l'initialisation va affiner l'extent, je n'ai pas beaucoup cherché d'où proviennent ces quelques pixels, mais globalement ça ne change pas grand chose, je ferais une update plus tard si je trouve.
- Je dois prendre en compte si j'ai une extent verticale ou horizontale pour affiner sa gestion, car j'ai l'impression que ça a un impact.


