### PR TITLE
#1240 - espace sous template

### DIFF
--- a/css/mviewer.css
+++ b/css/mviewer.css
@@ -1425,7 +1425,6 @@ li.mv-nav-item {
 #bottom-panel .featureInfo_allintabs .carousel-inner {
 	height: 100%;
 	overflow-y: auto;
-	padding-bottom: 5em;
 }
 
 /* Modes de template */


### PR DESCRIPTION
Correction issue #1240

Avant il y a un espace en dessous du bottom par défaut : https://kartenn.region-bretagne.fr/kartoviz/?x=-323482&y=6164493&z=8&l=rp_struct_pop_geom*rphab_tx0014%40commune*level%20%3D%20%27Commune%27&query=true&lb=osm&config=apps/default.xml&mode=d

Après, plus d'espacement : https://kartenn.region-bretagne.fr/kartoviz-dev/?x=-323482&y=6164493&z=8&l=rp_struct_pop_geom*rphab_tx0014%40commune*level%20%3D%20%27Commune%27&query=true&lb=osm&config=apps/default.xml&mode=d