### PR TITLE
extension - configuration depuis l'URL ou le XML

### DIFF
--- a/docs/doc_tech/config_customcomponent.rst
+++ b/docs/doc_tech/config_customcomponent.rst
@@ -32,7 +32,8 @@ Comment faire ?
 Un composant personnalisé - **customComponent** - est un dossier physique disposant d'un fichier obligatoire ``config.json`` qui identifie toutes les ressources à charger. Les ressources sont de 3 types :
 
 - ``html`` --> html à charger
-- ``css`` --> feuille de style à charger
+- ``css`` --> feuille(s) de style à charger, optionnelle. Cette propriété peut être
+  une chaîne (``"style.css"``) ou une liste de fichiers CSS.
 - ``js`` --> liste de fichiers javascripts à charger
 
 Exemple d'arborescence : ::
@@ -82,9 +83,61 @@ Voici un extrait de la configuration xml :
 
     <config>
         <extensions>
-            <extension type="component" id="3d" path="demo/components"/>
+            <extension type="component" id="3d" path="addons"/>
         </extensions>
     </config>
+
+
+Configurer un composant depuis le XML ou l'URL
+------------------------------------------------
+
+Les possibilités de configuration sont les suivantes :
+
+- **Choisir le fichier de configuration.**
+
+Par défaut, mviewer charge ``{path}/{id}/config.json``. L'attribut optionnel ``config`` permet de désigner un autre fichier, relatif à l'application ou sous la forme d'une URL absolue :
+
+  .. code-block:: XML
+
+      <extension
+          type="component"
+          id="print"
+          path="addons"
+          config="demo/print-config.json"/>
+
+  Les ressources déclarées dans ce fichier (``js``, ``css`` et ``html``) restent relatives au dossier du composant défini par ``path`` et ``id``.
+
+- **Définir des options dans le XML.**
+
+Elles permettent d'adapter un composant à une application sans modifier son fichier ``config.json`` :
+
+  .. code-block:: XML
+
+      <extension type="component" id="print" path="addons">
+          <config>
+              <options>
+                  <option name="printLayouts" value="addons/print/layouts/standard.json"/>
+                  <option name="ownerInfos" value="Cette carte a été réalisée pour mon organisation"/>
+              </options>
+          </config>
+      </extension>
+
+- **Surcharger les options depuis l'URL.**
+
+Les options résolues sont exposées aux scripts du composant dans ``mviewer.customComponents["mon-composant"].options``. Elles sont fusionnées dans l'ordre de priorité suivant :
+
+  #. paramètres de l'URL ;
+  #. options déclarées dans le XML ;
+  #. options du ``config.json``.
+
+  Les paramètres d'URL sont préfixés par l'identifiant du composant afin d'éviter les collisions. Par exemple, pour l'addon ``isochroneAddon`` :
+
+  .. code-block:: text
+
+      https://monsite.fr/mviewer/?config=demo/ign.xml&isochroneAddon.isoTitle=foobar&isochroneAddon.isochroneUrl=https%3A%2F%2Fdata.geopf.fr%2Fnavigation%2Fisochrone
+
+  Les valeurs peuvent être des chaînes ou des valeurs JSON encodées. Elles ne sont jamais exécutées comme du JavaScript.
+  Pour transmettre une URL comme valeur, encodez-la avec ``encodeURIComponent`` : ``https://data.geopf.fr/navigation/isochrone`` devient ``https%3A%2F%2Fdata.geopf.fr%2Fnavigation%2Fisochrone``. Cet encodage est indispensable si l'URL contient des caractères réservés, notamment ``?``, ``&`` ou ``#``.
 
 
 Exemples

--- a/js/configuration.js
+++ b/js/configuration.js
@@ -161,8 +161,13 @@ var configuration = (function () {
       components.forEach(function (component) {
         const id = component.getAttribute("id");
         const path = component.getAttribute("path");
+        const properties = Object.fromEntries(
+          Array.from(component.attributes)
+            .filter(({ name }) => !["id", "path", "type"].includes(name))
+            .map(({ name, value }) => [name, value])
+        );
         if (path && id) {
-          mviewer.customComponents[id] = new Component(id, path);
+          mviewer.customComponents[id] = new Component(id, path, properties);
         }
       });
     });

--- a/js/configuration.js
+++ b/js/configuration.js
@@ -166,8 +166,20 @@ var configuration = (function () {
             .filter(({ name }) => !["id", "path", "type"].includes(name))
             .map(({ name, value }) => [name, value])
         );
+        // read extensions options from xml config
+        const xmlOptions = Object.fromEntries(
+          Array.from(component.querySelectorAll("config > options > option"))
+            .filter((option) => option.hasAttribute("name"))
+            .map((option) => [
+              option.getAttribute("name"),
+              option.getAttribute("value") || option.textContent.trim(),
+            ])
+        );
         if (path && id) {
-          mviewer.customComponents[id] = new Component(id, path, properties);
+          mviewer.customComponents[id] = new Component(id, path, {
+            ...properties,
+            ...xmlOptions,
+          });
         }
       });
     });

--- a/js/configuration.js
+++ b/js/configuration.js
@@ -161,9 +161,10 @@ var configuration = (function () {
       components.forEach(function (component) {
         const id = component.getAttribute("id");
         const path = component.getAttribute("path");
+        const configPath = component.getAttribute("config");
         const properties = Object.fromEntries(
           Array.from(component.attributes)
-            .filter(({ name }) => !["id", "path", "type"].includes(name))
+            .filter(({ name }) => !["id", "path", "type", "config"].includes(name))
             .map(({ name, value }) => [name, value])
         );
         // read extensions options from xml config
@@ -176,10 +177,12 @@ var configuration = (function () {
             ])
         );
         if (path && id) {
-          mviewer.customComponents[id] = new Component(id, path, {
-            ...properties,
-            ...xmlOptions,
-          });
+          mviewer.customComponents[id] = new Component(
+            id,
+            path,
+            { ...properties, ...xmlOptions },
+            configPath
+          );
         }
       });
     });

--- a/js/configuration.js
+++ b/js/configuration.js
@@ -167,14 +167,13 @@ var configuration = (function () {
             .filter(({ name }) => !["id", "path", "type", "config"].includes(name))
             .map(({ name, value }) => [name, value])
         );
-        // read extensions options from xml config
+        // Read nested extension options through the shared XML-to-JSON utility.
+        const componentConfiguration = utils.xmlToJson(component);
+        const configuredOptions = componentConfiguration.config?.options?.option || [];
         const xmlOptions = Object.fromEntries(
-          Array.from(component.querySelectorAll("config > options > option"))
-            .filter((option) => option.hasAttribute("name"))
-            .map((option) => [
-              option.getAttribute("name"),
-              option.getAttribute("value") || option.textContent.trim(),
-            ])
+          (Array.isArray(configuredOptions) ? configuredOptions : [configuredOptions])
+            .filter((option) => option && typeof option === "object" && option.name)
+            .map((option) => [option.name, option.value ?? option["#text"] ?? ""])
         );
         if (path && id) {
           mviewer.customComponents[id] = new Component(

--- a/js/custom.js
+++ b/js/custom.js
@@ -60,9 +60,10 @@ class AdvancedCustomControl {
 }
 
 class Component {
-  constructor(id, path, properties = {}) {
+  constructor(id, path, properties = {}, configPath = "") {
     this.id = id;
     this.path = `${path}/${this.id}/`;
+    this.configPath = configPath || `${this.path}config.json`;
     this.properties = properties;
     this.urlProperties = this.getUrlProperties();
     this.config = {};
@@ -164,8 +165,8 @@ class Component {
       return response;
     };
 
-    const getConfig = function (path) {
-      return fetch(path + "config.json")
+    const getConfig = function (url) {
+      return fetch(url)
         .then(handleErrors)
         .then((response) => response.json())
         .catch(function (error) {
@@ -278,7 +279,7 @@ class Component {
       });
     };
 
-    getConfig(this.path) /* get config.json file */
+    getConfig(this.configPath) /* get configured config.json file */
       .then((json) => setConfig(json)) /* store json body in config variable */
       .then((config) =>
         getScripts(config)

--- a/js/custom.js
+++ b/js/custom.js
@@ -60,9 +60,10 @@ class AdvancedCustomControl {
 }
 
 class Component {
-  constructor(id, path) {
+  constructor(id, path, properties = {}) {
     this.id = id;
     this.path = `${path}/${this.id}/`;
+    this.properties = properties;
     this.config = {};
     this.load();
   }

--- a/js/custom.js
+++ b/js/custom.js
@@ -114,6 +114,7 @@ class Component {
     const mviewerOptions = options.mviewer?.[applicationId];
     const mviewersOptions = options.mviewers?.[applicationId];
     const applicationOptions = options[applicationId];
+    const componentOptions = options[this.id];
 
     if (mviewerOptions && typeof mviewerOptions === "object") {
       return mviewerOptions;
@@ -123,6 +124,9 @@ class Component {
     }
     if (applicationOptions && typeof applicationOptions === "object") {
       return applicationOptions;
+    }
+    if (componentOptions && typeof componentOptions === "object") {
+      return componentOptions;
     }
     return options;
   }

--- a/js/custom.js
+++ b/js/custom.js
@@ -64,8 +64,94 @@ class Component {
     this.id = id;
     this.path = `${path}/${this.id}/`;
     this.properties = properties;
+    this.urlProperties = this.getUrlProperties();
     this.config = {};
+    this.options = {};
     this.load();
+  }
+
+  /**
+   * Get URL options declared as `<component-id>.<property>`.
+   * For example: `?print.ownerInfos=Ma%20carte`.
+   *
+   * @returns {object}
+   */
+  getUrlProperties() {
+    const prefix = `${this.id}.`;
+    const searchParams = new URLSearchParams(window.location.search);
+
+    return Array.from(searchParams).reduce((properties, [name, value]) => {
+      if (name.startsWith(prefix)) {
+        properties[name.slice(prefix.length)] = this.parseUrlValue(value);
+      }
+      return properties;
+    }, {});
+  }
+
+  /**
+   * Parse JSON URL values while preserving regular strings.
+   *
+   * @param {string} value URL parameter value.
+   * @returns {*} Parsed JSON value, or the original string.
+   */
+  parseUrlValue(value) {
+    try {
+      return JSON.parse(value);
+    } catch (error) {
+      return value;
+    }
+  }
+
+  /**
+   * Resolve addon options for the current application.
+   *
+   * @param {object} options Options from config.json.
+   * @returns {object}
+   */
+  getApplicationOptions(options = {}) {
+    const applicationId = configuration.getConfiguration()?.application?.id;
+    const mviewerOptions = options.mviewer?.[applicationId];
+    const mviewersOptions = options.mviewers?.[applicationId];
+    const applicationOptions = options[applicationId];
+
+    if (mviewerOptions && typeof mviewerOptions === "object") {
+      return mviewerOptions;
+    }
+    if (mviewersOptions && typeof mviewersOptions === "object") {
+      return mviewersOptions;
+    }
+    if (applicationOptions && typeof applicationOptions === "object") {
+      return applicationOptions;
+    }
+    return options;
+  }
+
+  /**
+   * Merge addon options with URL > XML > config.json precedence.
+   *
+   * Unprefixed URL parameters are accepted only when their name is already
+   * defined by the addon configuration or the XML extension declaration.
+   *
+   * @param {object} options Options from config.json.
+   * @returns {object}
+   */
+  getOptions(options = {}) {
+    const configuredOptions = this.getApplicationOptions(options);
+    const urlProperties = Object.fromEntries(
+      Array.from(new URLSearchParams(window.location.search))
+        .filter(([name]) =>
+          Object.prototype.hasOwnProperty.call(configuredOptions, name) ||
+          Object.prototype.hasOwnProperty.call(this.properties, name)
+        )
+        .map(([name, value]) => [name, this.parseUrlValue(value)])
+    );
+
+    return {
+      ...configuredOptions,
+      ...this.properties,
+      ...urlProperties,
+      ...this.urlProperties,
+    };
   }
 
   load() {
@@ -89,7 +175,9 @@ class Component {
 
     const setConfig = function (config) {
       return new Promise((resolve, reject) => {
-        that.config = config;
+        that.config = config || {};
+        that.options = that.getOptions(that.config.options);
+        that.config.options = that.options;
         resolve(that.config);
       });
     };

--- a/js/custom.js
+++ b/js/custom.js
@@ -140,9 +140,10 @@ class Component {
     const configuredOptions = this.getApplicationOptions(options);
     const urlProperties = Object.fromEntries(
       Array.from(new URLSearchParams(window.location.search))
-        .filter(([name]) =>
-          Object.prototype.hasOwnProperty.call(configuredOptions, name) ||
-          Object.prototype.hasOwnProperty.call(this.properties, name)
+        .filter(
+          ([name]) =>
+            Object.prototype.hasOwnProperty.call(configuredOptions, name) ||
+            Object.prototype.hasOwnProperty.call(this.properties, name)
         )
         .map(([name, value]) => [name, this.parseUrlValue(value)])
     );

--- a/js/custom.js
+++ b/js/custom.js
@@ -169,28 +169,25 @@ class Component {
     const getConfig = function (url) {
       return fetch(url)
         .then(handleErrors)
-        .then((response) => response.json())
-        .catch(function (error) {
-          console.log(error);
-        });
+        .then((response) => response.json());
     };
 
     const setConfig = function (config) {
       return new Promise((resolve, reject) => {
         that.config = config || {};
         that.options = that.getOptions(that.config.options);
-        that.config.options = that.options;
         resolve(that.config);
       });
     };
 
     const getScripts = function (config) {
-      if (config) {
-        const requests = config.js.map((url) =>
-          loadScript(that.path + url, config?.type)
+      if (!config || !Array.isArray(config.js)) {
+        return Promise.reject(
+          new Error("Invalid component configuration: missing js array")
         );
-        return Promise.all(requests);
       }
+      const requests = config.js.map((url) => loadScript(that.path + url, config.type));
+      return Promise.all(requests);
     };
 
     const loadScript = function (src, type = "text/javascript") {
@@ -287,20 +284,12 @@ class Component {
       ) /* download all scripts from config.js array */
       .then((loadEvents) => getHTML()) /* download html file from config.html */
       .then((text) => setHTML(text))
-      .catch((e) => console.log(e)) /* store html body in config variable */
       .then((html) => render(html))
-      .catch((e) =>
-        console.log(e)
-      ) /* render html body in target element from config.target */
       .then((target) => dispatch())
-      .catch((e) => console.log(e)) /* dispatch componentLoaded event */
       .then((event) => {
-        if (event) {
-          console.log(`${that.id} is successfully loaded`);
-        } else {
-          console.log(`Error : ${that.id} is not loaded`);
-        }
-      });
+        console.log(`${that.id} is successfully loaded`);
+      })
+      .catch((error) => console.error(`Unable to load component "${that.id}".`, error));
   }
 }
 

--- a/js/utils/xml2json.js
+++ b/js/utils/xml2json.js
@@ -50,6 +50,8 @@ export function xmlToJson(xml) {
     return obj;
   }
 
-  const root = xml.documentElement;
+  // Accept either an XML document or an element. Component configuration is
+  // parsed directly from its <extension> element.
+  const root = xml.documentElement || xml;
   return parseNode(root);
 }


### PR DESCRIPTION
### Description

Cette PR contient les modifications pour :

- définir le chemin du config.json via l'URL #1358
- définir le chemin du config.json via le XML #1358 
- définir les paramètres de configuration via l'URL #1359 
- pouvoir définir dans le XML les paramètres de configuration #1363 #1365 
- pouvoir utiliser le config.json sans régression

- [ ] La documentation est à venir.


### Exemples

**Sommaire des exemples :** 

1. définir le chemin du fichier config.json via l'URL
2. définir le chemin du fichier config.json via le XML
3. définir les propriétés de l'addon via l'URL
4. définir les propriétés de l'addon via le XML
5. définir les propriétés de l'addon au sein du config.json (comportement actuel - évite les régression pour les cartes déjà en place)


**Exemples :**

1. définir le chemin du fichier config.json via l'URL

> http://localhost:5052/?config=demo/print.xml&?print.configUrl=addons/print/config.json

2. définir le chemin du fichier config.json via le XML

`<extension type="component" id="print" path="addons" config="addons/print/config.json">`

2. définir les paramètres de config de l'addon via l'URL

`http://localhost:5052/?config=demo/ign.xml&isochroneAddon.isoTitle=foobar&isochroneAddon.isochroneUrl=https%3A%2F%2Fdata.geopf.fr%2Fnavigation%2Fisochrone#`

4. définir la config de l'addon via le XML

> dans demo/ign.xml

```
    <extensions>    
		<extension type="component" id="isochroneAddon" path="addons">
			<config>
				<options>
					<option name="isochroneUrl" value="https://data.geopf.fr/isochrone"/>
					<option name="isoTitle" value="test"/>
					<option name="isohroneColor" value="#b45793"/>
				</options>
			</config>
		</extension>
    </extensions>
```


5. définir la config de l'addon au sein du config.json (comportement actuel - évite les régression pour les cartes déjà en place)

> contenu de addons/isochroneAddon/config.json

```
{
  "js": ["isochroneAddon.js", "../lib/jquery.easyDrag.min.js"],
  "css": "isochroneAddon.css",
  "html": "isochroneAddon.html",
  "target": "page-content-wrapper",
  "options": {
    "isoTitle": "Calcul d'isochrone",
    "isochroneUrl": "https://data.geopf.fr/navigation/isochrone?",
    "isohroneColor": "#b45793"
  }
}
```
