### PR TITLE
Iframe 955

### DIFF
--- a/js/configuration.js
+++ b/js/configuration.js
@@ -1132,8 +1132,24 @@ var configuration = (function () {
       mviewer.setBaseLayer(_defaultBaseLayer);
     }
 
-    if (_showhelp_startup && localStorage.getItem("helpCheckBox") !== "true") {
-      $("#help").modal("show");
+     if (_showhelp_startup && localStorage.getItem("helpCheckBox") !== "true") {
+      const helpModal = document.getElementById("help");
+
+      // different value into modal
+      if (window.self !== window.top) {
+        /**
+         * This fixes issue mviewer:
+         * https://github.com/mviewer/mviewer/issues/948
+         * 
+         * Bootstrap focuses the modal after opening it. Keep that focus without moving the document containing the iframe.
+         * 
+         */
+        helpModal.focus = function () {
+          HTMLElement.prototype.focus.call(this, { preventScroll: true });
+        };
+      }
+      // create and show modal instance
+      bootstrap.Modal.getOrCreateInstance(helpModal).show();
     }
 
     if (!API.wmc) {

--- a/js/configuration.js
+++ b/js/configuration.js
@@ -1132,7 +1132,7 @@ var configuration = (function () {
       mviewer.setBaseLayer(_defaultBaseLayer);
     }
 
-     if (_showhelp_startup && localStorage.getItem("helpCheckBox") !== "true") {
+    if (_showhelp_startup && localStorage.getItem("helpCheckBox") !== "true") {
       const helpModal = document.getElementById("help");
 
       // different value into modal
@@ -1140,9 +1140,9 @@ var configuration = (function () {
         /**
          * This fixes issue mviewer:
          * https://github.com/mviewer/mviewer/issues/948
-         * 
+         *
          * Bootstrap focuses the modal after opening it. Keep that focus without moving the document containing the iframe.
-         * 
+         *
          */
         helpModal.focus = function () {
           HTMLElement.prototype.focus.call(this, { preventScroll: true });


### PR DESCRIPTION
### Description

Cette PR propose un correctif à l'issue #955 en évitant le focus Bootstrap 5 d'une modal, lorsque l'application est chargée dans une iframe. 

### Comment tester ?

1. Utiliser une page HTML avec le contenu plus bas 
2. la source de l'iframe doit être une URL externe HTTPS - **dont le mviewer à afficher contient ce correctif**


```
<html lang="fr">
  <head>
    <title>MVIEWER Iframe example</title>
  </head>
  <body>
      
      <p>
        orem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur et felis lobortis, accumsan mi sit amet, vulputate turpis. Mauris quis pharetra dolor. Suspendisse commodo ante turpis. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec finibus condimentum mauris quis consectetur. Sed rhoncus molestie neque at fermentum. Nam non massa quis est mattis egestas ac at nibh. Integer risus quam, porta in bibendum id, efficitur non sapien. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam pretium, enim non elementum vulputate, augue metus posuere justo, eget fermentum augue arcu et sapien. Duis mattis molestie dapibus. Nunc ullamcorper euismod elit. Vestibulum vestibulum, ex at condimentum cursus, quam urna blandit magna, in pulvinar magna tellus quis augue. Pellentesque fermentum lorem vel ante accumsan blandit. Phasellus volutpat enim ac tortor pharetra cursus. Nulla arcu libero, luctus et enim sit amet, vestibulum finibus nulla.

Mauris cursus arcu a elit faucibus, at tincidunt magna rutrum. Fusce venenatis dolor elit, eu faucibus felis sollicitudin sit amet. Quisque fringilla mauris sed aliquam vulputate. Nulla scelerisque euismod orci non sagittis. Suspendisse molestie felis et blandit efficitur. Curabitur elementum lacus ex, in feugiat erat ultricies sit amet. Praesent rutrum lorem sed egestas pharetra. Praesent vestibulum vulputate velit nec convallis. Nulla facilisi. Donec nec pretium eros, quis maximus lacus. Aliquam erat volutpat. Proin nec dolor nibh. Aenean molestie aliquet hendrerit. Phasellus vel augue eget nisl egestas rutrum tincidunt vel urna.

Fusce consectetur fermentum sem ac scelerisque. Integer tempor malesuada nulla, non volutpat eros vehicula in. Donec in augue tortor. Sed ac elit eget augue efficitur rutrum ultricies eget massa. Nullam condimentum euismod augue facilisis feugiat. Sed fermentum ut enim vitae porta. Cras ultrices libero finibus odio semper, nec eleifend nibh egestas. Donec vitae risus laoreet nulla porta bibendum sed eu dui. Nullam ut massa scelerisque, porttitor erat id, faucibus sapien. Fusce elementum ipsum vitae malesuada laoreet. Suspendisse sem magna, lacinia euismod erat nec, commodo tristique mauris. Vestibulum condimentum lectus ac neque dignissim tincidunt. Nulla ac diam vel diam luctus vehicula ac sodales odio. Aliquam erat volutpat.

Integer non sodales metus, tristique fringilla est. Nullam vitae mauris eget leo laoreet viverra ut vitae mauris. Nulla commodo tincidunt mi, quis maximus ligula sollicitudin sed. Suspendisse et mi ac nunc dapibus commodo id vitae nunc. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; In vel leo libero. Nam vestibulum erat in ante malesuada porttitor a vel nunc.

In tortor ex, finibus quis dolor ut, bibendum vehicula nisl. Proin blandit elementum leo vestibulum euismod. Nunc euismod, quam eget pharetra congue, risus lorem porttitor nisl, in blandit ex diam vel lacus. In orci metus, ultrices eget nulla ac, porta feugiat lectus. Duis volutpat, sapien mattis finibus varius, nisi dolor efficitur ante, ut vestibulum ligula quam quis nunc. Sed eleifend odio risus. Aenean condimentum libero sapien, a rutrum mi bibendum a. Nulla ac sagittis felis. Sed massa elit, faucibus ut venenatis quis, vulputate sed diam. Mauris pharetra egestas quam, vitae convallis felis dictum id. Duis lobortis sapien ut mi bibendum, id vehicula nisl venenatis. Aenean eget posuere arcu. Vivamus tristique mi sed felis pulvinar tempor. Interdum et malesuada fames ac ante ipsum primis in faucibus.
    </p>
    <p style="margin-top:800px">
        <iframe src="http://gis.jdev.fr/mviewer-b5/?config=demo/fuse.xml" width="100%"  height="900px">
    </p>

  </body>
</script>
  </html>
```

