### PR TITLE
#561 - replace $.ajax  by fetch

### DIFF
--- a/js/addlayers.js
+++ b/js/addlayers.js
@@ -454,14 +454,33 @@ var addlayers = (function () {
     // parentDiv.append(item);
   };
   /**
-   * Wrap an AJAX call in a Promise.
-   * @param {Object} options - jQuery AJAX options.
-   * @returns {Promise} Promise resolved or rejected with the AJAX result.
+   * Fetch capabilities as text, preserving HTTP error details for the UI.
+   * @param {string} url - Capabilities URL to request.
+   * @returns {Promise<string>} Response text.
    */
-  var _ajaxPromise = function (options) {
-    return new Promise(function (resolve, reject) {
-      $.ajax(options).done(resolve).fail(reject);
+  var _fetchText = function (url) {
+    return fetch(url).then(async (response) => {
+      const text = await response.text();
+      if (!response.ok) {
+        const error = new Error(`HTTP ${response.status} ${response.statusText}`);
+        error.responseText = text;
+        throw error;
+      }
+      return text;
     });
+  };
+
+  /**
+   * Display a WMS or CSW request error with any details returned by the server.
+   * @param {Error|{responseText: string}} error - Request error or service report.
+   * @param {string} url - Requested service URL.
+   */
+  var _onRequestError = function (error, url) {
+    var message = `Problème réseau pour interroger <strong>${url}</strong><br>`;
+    if (error.responseText) {
+      message += error.responseText;
+    }
+    _error(message);
   };
 
   /**
@@ -600,37 +619,17 @@ var addlayers = (function () {
     document
       .querySelector("#addlayers_results_loading")
       ?.style.setProperty("display", "block");
-    _ajaxPromise({
-      url: url,
-      type: "get",
-      dataType: "text",
-    })
-      .then(
-        function onSuccess(data) {
-          const capabilities = capabilitiesParser.parse(data, url);
-          _resultList = capabilities;
-          if (_resultList !== null) {
-            _layerList = _resultList.layers;
-            _showLayerList(_layerList, document.querySelector("#addlayers_results"));
-          }
-          document
-            .querySelector("#addlayers_results_loading")
-            ?.style.setProperty("display", "none");
-        },
-        function onError(jqXHR, textStatus, errorThrown) {
-          var message = `Problème réseau pour intérroger <strong>${url}</strong><br>`;
-          if (jqXHR.responseText) {
-            message += jqXHR.responseText;
-          }
-          _error(message);
-          document
-            .querySelector("#addlayers_results_loading")
-            ?.style.setProperty("display", "none");
+    _fetchText(url)
+      .then(function onSuccess(data) {
+        const capabilities = capabilitiesParser.parse(data, url);
+        _resultList = capabilities;
+        if (_resultList !== null) {
+          _layerList = _resultList.layers;
+          _showLayerList(_layerList, document.querySelector("#addlayers_results"));
         }
-      )
-      .catch(function errorHandler(error) {
-        var message = `Problème réseau pour intérroger <strong>${url}</strong><br>`;
-        _error(message);
+      })
+      .catch((error) => _onRequestError(error, url))
+      .finally(function () {
         document
           .querySelector("#addlayers_results_loading")
           ?.style.setProperty("display", "none");
@@ -670,46 +669,25 @@ var addlayers = (function () {
     const url = `${_urlCsw}${params}&constraintLanguage=CQL_TEXT&CONSTRAINT_LANGUAGE_VERSION=1.1.0&CONSTRAINT=${filter}`;
     // Show
     addLayersResultsLoading.style.display = "block";
-    _ajaxPromise({
-      url: url,
-      type: "get",
-      dataType: "text",
-    })
-      .then(
-        function onSuccess(data) {
-          if (data.indexOf("ExceptionReport") > 0) {
-            let message = `Problème réseau pour intérroger <strong>${url}</strong><br>`;
-            message += data;
-            _error(message);
-            return;
-          }
-          const capabilities = capabilitiesParser.parseCSW(data, url);
-          _resultList = capabilities;
-          if (_resultList !== null) {
-            _layerList = _resultList.layers;
-            _pagingInfos.nbPages = Math.ceil(
-              _resultList.nbTotalResults / _pagingInfos.pageSize
-            );
-            _showLayerList(_layerList, addLayersResults);
-            _addPager();
-          }
-          // Hide
-          addLayersResultsLoading.style.display = "none";
-        },
-        function onError(jqXHR, textStatus, errorThrown) {
-          var message = `Problème réseau pour intérroger <strong>${url}</strong><br>`;
-          if (jqXHR.responseText) {
-            message += jqXHR.responseText;
-          }
-          _error(message);
-          // Hide
-          addLayersResultsLoading.style.display = "none";
+    _fetchText(url)
+      .then(function onSuccess(data) {
+        if (data.indexOf("ExceptionReport") >= 0) {
+          _onRequestError({ responseText: data }, url);
+          return;
         }
-      )
-      .catch(function errorHandler(error) {
-        var message = `Problème réseau pour intérroger <strong>${url}<strong><br>`;
-        _error(message);
-        // Hide
+        const capabilities = capabilitiesParser.parseCSW(data, url);
+        _resultList = capabilities;
+        if (_resultList !== null) {
+          _layerList = _resultList.layers;
+          _pagingInfos.nbPages = Math.ceil(
+            _resultList.nbTotalResults / _pagingInfos.pageSize
+          );
+          _showLayerList(_layerList, addLayersResults);
+          _addPager();
+        }
+      })
+      .catch((error) => _onRequestError(error, url))
+      .finally(function () {
         addLayersResultsLoading.style.display = "none";
       });
   };

--- a/js/configuration.js
+++ b/js/configuration.js
@@ -415,9 +415,15 @@ var configuration = (function () {
       _authentification.url = conf.authentification.url;
       _authentification.loginurl = conf.authentification.loginurl;
       _authentification.logouturl = conf.authentification.logouturl;
-      $.ajax({
-        url: _authentification.url,
-        success: function (response) {
+      fetch(_authentification.url, {
+        headers: { Accept: "application/json, text/javascript, */*; q=0.01" },
+      })
+        .then((response) => {
+          if (!response.ok)
+            throw new Error(`HTTP ${response.status} ${response.statusText}`);
+          return response.json();
+        })
+        .then(function (response) {
           //test georchestra proxy
           if (response.proxy == "true") {
             document.querySelector("#login-box")?.style.setProperty("display", "");
@@ -456,8 +462,8 @@ var configuration = (function () {
               ].join("\n")
             );
           }
-        },
-      });
+        })
+        .catch((error) => console.error(error));
     }
 
     //baselayertoolbar
@@ -502,48 +508,54 @@ var configuration = (function () {
       var nbOverLayers = 0;
 
       var requests = [];
-      var ajaxFunction = function () {
-        // Préparation des requêtes Ajax pour récupérer les thématiques externes
-        wmcs.forEach(function (url, idx) {
-          var wmcid = `wmc${idx}`;
-          requests.push(
-            $.ajax({
-              url: mviewer.ajaxURL(url, _proxy),
-              crossDomain: true,
-              wmcid: wmcid,
-              dataType: "xml",
-              success: function (response, textStatus, request) {
-                var wmc = mviewer.parseWMCResponse(response, this.wmcid);
-                wmc.layers.forEach(function (layer) {
-                  mviewer.processLayer(layer, layer.layer);
-                });
-                processedWMC += 1;
-                _themes[wmcid] = {};
-                _themes[wmcid].collapsed = false;
-                _themes[wmcid].id = wmcid;
-                _themes[wmcid].name = wmc.title;
-                _themes[wmcid].layers = {};
-                _themes[wmcid].icon = "fas fa-chevron-circle-right";
-                _map.getView().fit(wmc.extent, {
-                  size: _map.getSize(),
-                  padding: [
-                    0,
-                    document.querySelector("#sidebar-wrapper").offsetWidth,
-                    0,
-                    0,
-                  ],
-                });
-                _themes[wmcid].layers = wmc.layers;
-                _themes[wmcid].name = wmc.title;
-                nbOverLayers += Object.keys(wmc.layers).length;
-              },
-              error: function (xhr, status, error) {
-                console.log(`WMC ${this.url} not found`);
-              },
+      // Récupération des thématiques externes avant de signaler la fin du chargement.
+      wmcs.forEach(function (url, idx) {
+        var wmcid = `wmc${idx}`;
+        requests.push(
+          fetch(mviewer.ajaxURL(url, _proxy), {
+            headers: { Accept: "application/xml, text/xml, */*; q=0.01" },
+          })
+            .then((response) => {
+              if (!response.ok)
+                throw new Error(`HTTP ${response.status} ${response.statusText}`);
+              return response.text();
             })
-          );
-        });
-      };
+            .then((text) => {
+              const xml = new DOMParser().parseFromString(text, "text/xml");
+              if (xml.querySelector("parsererror"))
+                throw new Error("Invalid XML response");
+              return xml;
+            })
+            .then(function (response) {
+              var wmc = mviewer.parseWMCResponse(response, wmcid);
+              wmc.layers.forEach(function (layer) {
+                mviewer.processLayer(layer, layer.layer);
+              });
+              processedWMC += 1;
+              _themes[wmcid] = {};
+              _themes[wmcid].collapsed = false;
+              _themes[wmcid].id = wmcid;
+              _themes[wmcid].name = wmc.title;
+              _themes[wmcid].layers = {};
+              _themes[wmcid].icon = "fas fa-chevron-circle-right";
+              _map.getView().fit(wmc.extent, {
+                size: _map.getSize(),
+                padding: [
+                  0,
+                  document.querySelector("#sidebar-wrapper").offsetWidth,
+                  0,
+                  0,
+                ],
+              });
+              _themes[wmcid].layers = wmc.layers;
+              _themes[wmcid].name = wmc.title;
+              nbOverLayers += Object.keys(wmc.layers).length;
+            })
+            .catch(function (error) {
+              console.log(`WMC ${mviewer.ajaxURL(url, _proxy)} not found`);
+            })
+        );
+      });
 
       Promise.allSettled(requests).then(function () {
         mviewer.events().overLayersTotal = nbOverLayers;
@@ -653,22 +665,32 @@ var configuration = (function () {
               var secureLayer =
                 layer.secure === "true" || layer.secure == "global" ? true : false;
               if (secureLayer) {
-                $.ajax({
-                  dataType: "xml",
-                  layer: layerId,
-                  url: mviewer.ajaxURL(getCapRequestUrl),
-                  success: function (result) {
+                fetch(mviewer.ajaxURL(getCapRequestUrl), {
+                  headers: { Accept: "application/xml, text/xml, */*; q=0.01" },
+                })
+                  .then((response) => {
+                    if (!response.ok)
+                      throw new Error(`HTTP ${response.status} ${response.statusText}`);
+                    return response.text();
+                  })
+                  .then((text) => {
+                    const xml = new DOMParser().parseFromString(text, "text/xml");
+                    if (xml.querySelector("parsererror"))
+                      throw new Error("Invalid XML response");
+                    return xml;
+                  })
+                  .then(function (result) {
                     //Find layer in capabilities
-                    var name = this.layer;
+                    var name = layerId;
                     const layer = Array.from(
                       result.querySelectorAll("Layer > Name")
                     ).find((element) => element.textContent === name);
                     if (!layer) {
                       //remove this layer from map and panel
-                      mviewer.deleteLayer(this.layer);
+                      mviewer.deleteLayer(layerId);
                     }
-                  },
-                });
+                  })
+                  .catch((error) => console.error(error));
               }
             }
             var mvid;
@@ -933,34 +955,43 @@ var configuration = (function () {
 
             if (oLayer.customcontrol) {
               var customcontrolpath = oLayer.customcontrolpath;
-              $.ajax({
-                url: `${customcontrolpath}/${oLayer.id}.js`,
-                layer: oLayer.id,
-                dataType: "script",
-                success: function (customLayer, textStatus, request) {
-                  $.ajax({
-                    url: `${customcontrolpath}/${this.layer}.html`,
-                    layer: oLayer.id,
-                    dataType: "text",
-                    success: function (html) {
-                      mviewer.customControls[this.layer].form = html;
+              fetch(`${customcontrolpath}/${oLayer.id}.js`)
+                .then((response) => {
+                  if (!response.ok)
+                    throw new Error(`HTTP ${response.status} ${response.statusText}`);
+                  return response.text();
+                })
+                .then((source) => {
+                  const script = document.createElement("script");
+                  script.textContent = source;
+                  document.head.appendChild(script);
+                  script.remove();
+                })
+                .then(function () {
+                  fetch(`${customcontrolpath}/${oLayer.id}.html`)
+                    .then((response) => {
+                      if (!response.ok)
+                        throw new Error(`HTTP ${response.status} ${response.statusText}`);
+                      return response.text();
+                    })
+                    .then(function (html) {
+                      mviewer.customControls[oLayer.id].form = html;
                       const layerDetails = document.querySelector(
-                        `.mv-layer-details[data-layerid="${this.layer}"]`
+                        `.mv-layer-details[data-layerid="${oLayer.id}"]`
                       );
                       if (layerDetails) {
                         //append the existing mv-layers-details panel
                         layerDetails
                           .querySelector(".mv-custom-controls")
                           ?.insertAdjacentHTML("beforeend", html);
-                        mviewer.customControls[this.layer].init();
+                        mviewer.customControls[oLayer.id].init();
                       }
-                    },
-                  });
-                },
-                error: function () {
+                    })
+                    .catch((error) => console.error(error));
+                })
+                .catch(function (error) {
                   alert("error customControl");
-                },
-              });
+                });
             }
 
             themeLayers[oLayer.id] = oLayer;
@@ -1221,10 +1252,19 @@ var configuration = (function () {
               if (oLayer.url && oLayer.url.slice(-3) === ".js") {
                 hook_url = oLayer.url;
               }
-              $.ajax({
-                url: mviewer.ajaxURL(hook_url),
-                dataType: "script",
-                success: function (customLayer, textStatus, request) {
+              fetch(mviewer.ajaxURL(hook_url))
+                .then((response) => {
+                  if (!response.ok)
+                    throw new Error(`HTTP ${response.status} ${response.statusText}`);
+                  return response.text();
+                })
+                .then((source) => {
+                  const script = document.createElement("script");
+                  script.textContent = source;
+                  document.head.appendChild(script);
+                  script.remove();
+                })
+                .then(function () {
                   if (mviewer.customLayers[oLayer.id].layer) {
                     var l = mviewer.customLayers[oLayer.id].layer;
                     if (oLayer.style && mviewer.featureStyles[oLayer.style]) {
@@ -1232,11 +1272,10 @@ var configuration = (function () {
                     }
                     mviewer.processLayer(oLayer, l);
                   }
-                },
-                error: function (request, textStatus, error) {
+                })
+                .catch(function (error) {
                   console.log(`error with custom Layer ${oLayer.id} : ${error}`);
-                },
-              });
+                });
             }
             if (layer.group) {
               _themes[themeid].groups[layer.group].layers[oLayer.id] = oLayer;

--- a/js/info.js
+++ b/js/info.js
@@ -984,20 +984,17 @@ var info = (function () {
     urls.forEach(function (request) {
       var _ba_ident = sessionStorage.getItem(request.layerinfos.url);
       requests.push(
-        $.ajax({
-          url: mviewer.ajaxURL(request.url),
-          layer: request.layerinfos,
-          beforeSend: function (req) {
-            if (_ba_ident)
-              req.setRequestHeader("Authorization", `Basic ${btoa(_ba_ident)}`);
-          },
-          success: function (response, textStatus, request) {
-            featureInfoByLayer.push({
-              response: response,
-              layerinfos: this.layer,
-              contenttype: request.getResponseHeader("Content-Type"),
-            });
-          },
+        fetch(mviewer.ajaxURL(request.url), {
+          headers: _ba_ident ? { Authorization: `Basic ${btoa(_ba_ident)}` } : {},
+        }).then(async (response) => {
+          if (!response.ok) {
+            throw new Error(`HTTP ${response.status} ${response.statusText}`);
+          }
+          featureInfoByLayer.push({
+            response: await response.text(),
+            layerinfos: request.layerinfos,
+            contenttype: response.headers.get("Content-Type") || "",
+          });
         })
       );
     });
@@ -1005,9 +1002,9 @@ var info = (function () {
     // in case of mobile, translate
 
     // wait all request before show info panel
-    Promise.all(requests).then(() => {
-      callback();
-    });
+    Promise.all(requests)
+      .then(() => callback())
+      .catch((error) => console.error(error));
   }
 
   /**

--- a/js/mviewer.js
+++ b/js/mviewer.js
@@ -928,15 +928,18 @@ mviewer = (function () {
 
   var _initPanelsPopup = function () {
     if (configuration.getConfiguration().application.help) {
-      $.ajax({
-        url: configuration.getConfiguration().application.help,
-        dataType: "text",
-        success: function (html) {
+      fetch(configuration.getConfiguration().application.help)
+        .then((response) => {
+          if (!response.ok)
+            throw new Error(`HTTP ${response.status} ${response.statusText}`);
+          return response.text();
+        })
+        .then(function (html) {
           document
             .querySelector("#help .modal-body")
             ?.insertAdjacentHTML("beforeend", html);
-        },
-      });
+        })
+        .catch((error) => console.error(error));
     }
   };
 
@@ -1021,11 +1024,20 @@ mviewer = (function () {
     _overLayers[oLayer.id] = oLayer;
 
     if (oLayer.metadatacsw && oLayer.metadatacsw.search("http") >= 0) {
-      $.ajax({
-        dataType: "xml",
-        layer: oLayer.id,
-        url: _ajaxURL(oLayer.metadatacsw),
-        success: function (result) {
+      fetch(_ajaxURL(oLayer.metadatacsw), {
+        headers: { Accept: "application/xml, text/xml, */*; q=0.01" },
+      })
+        .then((response) => {
+          if (!response.ok)
+            throw new Error(`HTTP ${response.status} ${response.statusText}`);
+          return response.text();
+        })
+        .then((text) => {
+          const xml = new DOMParser().parseFromString(text, "text/xml");
+          if (xml.querySelector("parsererror")) throw new Error("Invalid XML response");
+          return xml;
+        })
+        .then(function (result) {
           var summary = "";
           const getXmlText = (selector) =>
             result.querySelector(selector)?.textContent || "";
@@ -1034,33 +1046,33 @@ mviewer = (function () {
           } else {
             summary = `<p>${getXmlText("gmd\\:identificationInfo gmd\\:MD_DataIdentification gmd\\:abstract gco\\:CharacterString, identificationInfo MD_DataIdentification abstract CharacterString")}</p>`;
           }
-          if (_overLayers[this.layer].metadata) {
+          if (_overLayers[oLayer.id].metadata) {
             summary += `<a href="${
-              _overLayers[this.layer].metadata
+              _overLayers[oLayer.id].metadata
             }" i18n="legend.moreinfo" target="_blank">En savoir plus</a>`;
           }
-          _overLayers[this.layer].summary = summary;
+          _overLayers[oLayer.id].summary = summary;
 
           var modifiedDate =
             getXmlText("dct\\:modified, modified") ||
             getXmlText("dct\\:created, created");
-          _overLayers[this.layer].modifiedDate = modifiedDate;
+          _overLayers[oLayer.id].modifiedDate = modifiedDate;
 
           //use source from metadata as attribution if conf is set to "metadata"
-          if (_overLayers[this.layer].attribution === "metadata") {
+          if (_overLayers[oLayer.id].attribution === "metadata") {
             var source = getXmlText("dc\\:source, source");
-            _overLayers[this.layer].attribution = `Source : ${source}`;
-            document.querySelector(`#${this.layer}-attribution`).textContent =
+            _overLayers[oLayer.id].attribution = `Source : ${source}`;
+            document.querySelector(`#${oLayer.id}-attribution`).textContent =
               `Source : ${source}`;
           }
 
           //update visible layers on the map
           document
-            .querySelector(`#${this.layer}-layer-summary`)
+            .querySelector(`#${oLayer.id}-layer-summary`)
             ?.setAttribute("data-bs-content", summary);
-          document.querySelector(`#${this.layer}-date`).textContent = modifiedDate;
-        },
-      });
+          document.querySelector(`#${oLayer.id}-date`).textContent = modifiedDate;
+        })
+        .catch((error) => console.error(error));
     }
     _map.addLayer(l);
     if (oLayer.type === "customlayer" && mviewer.customLayers[oLayer.id]) {
@@ -1678,15 +1690,27 @@ mviewer = (function () {
           _map.addLayer(l);
           _backgroundLayers.push(l);
         } else {
-          $.ajax({
-            url: _ajaxURL(baselayer.url),
-            dataType: "xml",
-            data: {
-              SERVICE: "WMTS",
-              VERSION: "1.0.0",
-              REQUEST: "GetCapabilities",
-            },
-            success: function (xml) {
+          const capabilitiesUrl = new URL(_ajaxURL(baselayer.url), document.baseURI);
+          new URLSearchParams({
+            SERVICE: "WMTS",
+            VERSION: "1.0.0",
+            REQUEST: "GetCapabilities",
+          }).forEach((value, key) => capabilitiesUrl.searchParams.append(key, value));
+          fetch(capabilitiesUrl, {
+            headers: { Accept: "application/xml, text/xml, */*; q=0.01" },
+          })
+            .then((response) => {
+              if (!response.ok)
+                throw new Error(`HTTP ${response.status} ${response.statusText}`);
+              return response.text();
+            })
+            .then((text) => {
+              const xml = new DOMParser().parseFromString(text, "text/xml");
+              if (xml.querySelector("parsererror"))
+                throw new Error("Invalid XML response");
+              return xml;
+            })
+            .then(function (xml) {
               var getCapabilitiesResult = new ol.format.WMTSCapabilities().read(xml);
               var WMTSOptions = ol.source.WMTS.optionsFromCapabilities(
                 getCapabilitiesResult,
@@ -1709,8 +1733,8 @@ mviewer = (function () {
               } else {
                 l.setVisible(false);
               }
-            },
-          });
+            })
+            .catch((error) => console.error(error));
         }
         break;
 
@@ -2391,14 +2415,18 @@ mviewer = (function () {
       var extraFile = configuration.getConfiguration().application.langfile;
       var defaultFile = "mviewer.i18n.json";
       if (!extraFile) {
-        $.ajax({
-          url: defaultFile,
-          dataType: "json",
-          success: _configureTranslate,
-          error: function () {
+        fetch(defaultFile, {
+          headers: { Accept: "application/json, text/javascript, */*; q=0.01" },
+        })
+          .then((response) => {
+            if (!response.ok)
+              throw new Error(`HTTP ${response.status} ${response.statusText}`);
+            return response.json();
+          })
+          .then(_configureTranslate)
+          .catch(function (error) {
             console.log("Error: can't load JSON lang file!");
-          },
-        });
+          });
       } else {
         Promise.all([
           fetch(defaultFile).then((r) => r.json()),

--- a/js/search.js
+++ b/js/search.js
@@ -787,16 +787,20 @@ var search = (function () {
         contentType = "application/json; charset=utf-8";
       }
       if (sendQuery) {
-        // Fix IE9 "No transport error" with cors
-        jQuery.support.cors = true;
-        $.ajax({
-          type: "POST",
-          url: _elasticSearchUrl,
-          crossDomain: true,
-          data: JSON.stringify(queryFilter),
-          dataType: "json",
-          contentType: contentType,
-          success: function (data) {
+        fetch(_elasticSearchUrl, {
+          method: "POST",
+          headers: {
+            "Content-Type": contentType,
+            Accept: "application/json, text/javascript, */*; q=0.01",
+          },
+          body: JSON.stringify(queryFilter),
+        })
+          .then((response) => {
+            if (!response.ok)
+              throw new Error(`HTTP ${response.status} ${response.statusText}`);
+            return response.json();
+          })
+          .then(function (data) {
             _sourceEls.clear();
             var str = "";
             var format = new ol.format.GeoJSON();
@@ -840,8 +844,8 @@ var search = (function () {
             if (nb > 0) {
               _showResults(str, "entities");
             }
-          },
-          error: function (xhr, ajaxOptions, thrownError) {
+          })
+          .catch(function (thrownError) {
             mviewer.alert(
               `Problème avec l'instance Elasticsearch.\n${thrownError}\n Désactivation du service.`,
               "alert-warning"
@@ -854,8 +858,7 @@ var search = (function () {
                 element.classList.remove("mv-checked");
                 element.classList.add("mv-unchecked");
               });
-          },
-        });
+          });
       }
     }
   };
@@ -936,16 +939,20 @@ var search = (function () {
           }
           contentType = "application/json; charset=utf-8";
           if (sendQuery) {
-            // Fix IE9 "No transport error" with cors
-            jQuery.support.cors = true;
-            $.ajax({
-              type: "POST",
-              url: _elasticSearchUrl.get(layerId),
-              crossDomain: true,
-              data: JSON.stringify(queryFilter),
-              dataType: "json",
-              contentType: contentType,
-              success: function (data) {
+            fetch(_elasticSearchUrl.get(layerId), {
+              method: "POST",
+              headers: {
+                "Content-Type": contentType,
+                Accept: "application/json, text/javascript, */*; q=0.01",
+              },
+              body: JSON.stringify(queryFilter),
+            })
+              .then((response) => {
+                if (!response.ok)
+                  throw new Error(`HTTP ${response.status} ${response.statusText}`);
+                return response.json();
+              })
+              .then(function (data) {
                 let str = "";
                 let indexId = "";
                 let mouseOverField = "";
@@ -1039,8 +1046,8 @@ var search = (function () {
                 if (nb > 0) {
                   _showResults(str, "entities");
                 }
-              },
-              error: function (xhr, ajaxOptions, thrownError) {
+              })
+              .catch(function (thrownError) {
                 mviewer.alert(
                   `Problème avec l'instance Elasticsearch.\n${thrownError}\n Désactivation du service.`,
                   "alert-warning"
@@ -1053,8 +1060,7 @@ var search = (function () {
                     element.classList.remove("mv-checked");
                     element.classList.add("mv-unchecked");
                   });
-              },
-            });
+              });
           }
         }
       }


### PR DESCRIPTION
> ref #561 

Dans la continuité de la suppression de JQuery,
Cette PR proposer un remplacement des selecteurs / méthodes d'appel JQuery $.ajax par fetch.

Le loader de chargement de couche est également géré à un seul endroit en fin d'appel (voir id `addlayers_results_loading`).